### PR TITLE
Fixing scons dependencies to build third_party/dpdk prior to vrouter/dpdk.

### DIFF
--- a/dpdk/SConscript
+++ b/dpdk/SConscript
@@ -58,7 +58,7 @@ dpdk_vrouter_src = [ 'dpdk_vrouter.c',
                    ]
 
 dpdk_vrouter = env.Program('contrail-vrouter-dpdk', dpdk_vrouter_src)
-env.Depends(dpdk_vrouter, dpdk_lib)
+env.Requires(dpdk_vrouter, dpdk_lib)
 
 if GetOption('clean'):
     os.system('cd ' + make_dir + ';' + make_cmd + ' clean')


### PR DESCRIPTION
One line fix on SConscript that enables dpdk library buind build as prerequisite for vrouter/dpdk.
