### PR TITLE
Initial vRouter/DPDK monitoring interface support

### DIFF
--- a/dp-core/vr_interface.c
+++ b/dp-core/vr_interface.c
@@ -912,8 +912,8 @@ static struct vr_interface_driver vif_drivers[VIF_TYPE_MAX] = {
         .drv_delete                 =   vlan_drv_del,
     },
     [VIF_TYPE_STATS] = {
-        .drv_add        =   eth_drv_add,
-        .drv_delete     =   eth_drv_del,
+        .drv_add                    =   eth_drv_add,
+        .drv_delete                 =   eth_drv_del,
     },
 };
 

--- a/dp-core/vr_interface.c
+++ b/dp-core/vr_interface.c
@@ -915,6 +915,10 @@ static struct vr_interface_driver vif_drivers[VIF_TYPE_MAX] = {
         .drv_add                    =   eth_drv_add,
         .drv_delete                 =   eth_drv_del,
     },
+    [VIF_TYPE_MONITORING] = {
+        .drv_add                    =   vhost_drv_add,
+        .drv_delete                 =   vhost_drv_del,
+    },
 };
 
 

--- a/dpdk/dpdk_vrouter.c
+++ b/dpdk/dpdk_vrouter.c
@@ -370,7 +370,7 @@ main(int argc, char *argv[])
 
         case '?':
         default:
-            fprintf(stderr, "Invalid option %s\n", argv[optind]);
+            fprintf(stderr, "Invalid option %s\n", argv[optind - 1]);
             exit(-EINVAL);
             break;
         }

--- a/dpdk/vr_dpdk_ethdev.c
+++ b/dpdk/vr_dpdk_ethdev.c
@@ -92,9 +92,9 @@ static const struct rte_eth_rxconf rx_queue_conf = {
 /* TX ring configuration */
 static const struct rte_eth_txconf tx_queue_conf = {
     .tx_thresh = {
-        .pthresh = 36,  /* Ring prefetch threshold */
+        .pthresh = 32,  /* Ring prefetch threshold */
         .hthresh = 0,   /* Ring host threshold */
-        .wthresh = 0,   /* Ring writeback threshold */
+        .wthresh = 16,   /* Ring writeback threshold */
     },
     .tx_free_thresh = 0,    /* Use PMD default values */
     .tx_rs_thresh = 0,      /* Use PMD default values */

--- a/dpdk/vr_dpdk_interface.c
+++ b/dpdk/vr_dpdk_interface.c
@@ -284,10 +284,6 @@ dpdk_vhost_if_add(struct vr_interface *vif)
     /* add interface to the table of vHosts */
     vr_dpdk.vhosts[vif->vif_idx] = vrouter_get_interface(vif->vif_rid, vif->vif_idx);
 
-    /*
-     * TODO: schedule KNI queues - set number of queues to 0 for now so that
-     * vhost does not affect queue scheduling on lcores.
-     */
     return vr_dpdk_lcore_if_schedule(vif, vr_dpdk_lcore_least_used_get(),
             1, &vr_dpdk_kni_rx_queue_init,
             1, &vr_dpdk_kni_tx_queue_init);

--- a/dpdk/vr_dpdk_interface.c
+++ b/dpdk/vr_dpdk_interface.c
@@ -322,8 +322,9 @@ dpdk_monitoring_if_add(struct vr_interface *vif)
 
     /* check if KNI is already added */
     if (vr_dpdk.knis[vif->vif_idx] != NULL) {
-        RTE_LOG(ERR, VROUTER, "\terror adding monitoring device %s: already exist\n",
-                vif->vif_name);
+        RTE_LOG(ERR, VROUTER, "\terror adding monitoring device %s: "
+                "vif %d already exist\n",
+                vif->vif_name, vif->vif_idx);
         return -EEXIST;
     }
 

--- a/dpdk/vr_dpdk_knidev.c
+++ b/dpdk/vr_dpdk_knidev.c
@@ -324,6 +324,8 @@ vr_dpdk_knidev_init(struct vr_interface *vif)
         else
             /* ...so we use os_idx instead */
             port_id = vif->vif_os_idx;
+    } else if (vif->vif_type == VIF_TYPE_MONITORING) {
+            port_id = 0; /* we always use DPDK port 0 */
     } else {
         RTE_LOG(ERR, VROUTER, "\tunknown KNI interface addition"
                 "type %d os index %d\n", vif->vif_type, vif->vif_os_idx);
@@ -374,7 +376,8 @@ vr_dpdk_knidev_all_handle(void)
 
     for (i = 0; i < router->vr_max_interfaces; i++) {
         vif = __vrouter_get_interface(router, i);
-        if (vif && (vif->vif_type == VIF_TYPE_HOST))
+        if (vif && (vif->vif_type == VIF_TYPE_HOST
+                    || vif->vif_type == VIF_TYPE_MONITORING))
             rte_kni_handle_request((struct rte_kni *)vif->vif_os);
     }
 }

--- a/examples/monitoring/VROUTER1/00.config.sh
+++ b/examples/monitoring/VROUTER1/00.config.sh
@@ -1,0 +1,77 @@
+##
+## vRouter/DPDK Configuration File
+## Copyright (c) 2014 Semihalf. All rights reserved.
+##
+## Monitoring testing scripts:
+##
+##   VM1 -- VROUTER1 -- <monitoring interface> -- tcpdump
+##
+
+# Compile optimization method
+OPTIMIZATION="production"
+
+#################################################################
+## DIRECTORIES
+# Contrail project base directory
+CONTRAIL_DIR="${HOME}/contrail"
+# HugeTLBfs mount point
+TLBFS_DIR="/hugepages"
+# DPDK base directory
+DPDK_DIR="${CONTRAIL_DIR}/third_party/dpdk"
+# User space vHost prefix
+UVH_PREFIX="/var/tmp/uvh_vif"
+
+#################################################################
+## INTERFACES
+# NIC PCI addresses
+VROUTER1_1_PCI="06:00.1"
+VROUTER1_1_PCI_DBDF="0x601"
+VROUTER1_2_PCI="04:00.1"
+VROUTER1_2_PCI_DBDF="0x401"
+# NIC Linux interfaces to bind
+VROUTER1_1_IF="eth1"
+VROUTER1_2_IF="eth3"
+# DPDK ports
+VROUTER1_1_PORT="0"
+VROUTER1_2_PORT="1"
+# NIC Linux drivers (for the unbind)
+VROUTER1_1_DRV="igb"
+VROUTER1_2_DRV="ixgbe"
+# default IP addresses (for the unbind)
+VROUTER1_1_DEF_IP="172.16.1.100"
+VROUTER1_2_DEF_IP="172.16.2.100"
+# MAC addresses
+VM1_MAC="90:e2:ba:3f:c7:60"
+VROUTER1_1_MAC="0c:c4:7a:16:33:9f"
+VROUTER1_2_MAC="90:e2:ba:3f:c7:69"
+VROUTER2_1_MAC="90:e2:ba:3f:c5:e8"
+VM2_MAC="90:e2:ba:3f:c7:60"
+# Monitoring interfaces
+VROUTER1_MON0="mon0"
+VROUTER1_MON1="mon1"
+# Fake Agent interface to disable xconnect mode
+VROUTER2_AGENT_IF="tap100"
+# IPs
+VM1_IP="172.16.1.1"
+VM2_IP="172.16.1.129"
+VROUTER1_VHOST_IP="172.16.1.101"
+VROUTER2_VHOST_IP="172.16.1.102"
+
+
+#################################################################
+## OTHER
+# MPLS label to use
+MPLS_LABEL=22
+
+# Number of HugePages
+NB_HUGEPAGES=2048
+
+# vRouter Utils
+MPLS="${CONTRAIL_DIR}/build/${OPTIMIZATION}/vrouter/utils/mpls"
+NH="${CONTRAIL_DIR}/build/${OPTIMIZATION}/vrouter/utils/nh"
+RT="${CONTRAIL_DIR}/build/${OPTIMIZATION}/vrouter/utils/rt"
+VIF="${CONTRAIL_DIR}/build/${OPTIMIZATION}/vrouter/utils/vif"
+VROUTER="${CONTRAIL_DIR}/build/${OPTIMIZATION}/vrouter/dpdk/contrail-vrouter-dpdk"
+
+# Bind Tool
+BIND="${DPDK_DIR}/tools/dpdk_nic_bind.py"

--- a/examples/monitoring/VROUTER1/10.setup-linux.sh
+++ b/examples/monitoring/VROUTER1/10.setup-linux.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+##
+## Linux Setup Script
+## Copyright (c) 2014 Semihalf. All rights reserved.
+##
+## - mount HugeTLBfs
+## - configure hugepages
+##
+
+. 00.config.sh
+
+
+#################################################################
+## Mount HugeTLBfs
+# check if already mounted
+_mount=`mount | grep hugetlbfs`
+if [ "x${_mount}" != "x" ]; then
+    echo -e "HugeTLBfs is already mounted:\n${_mount}"
+else
+    echo "Mounting HugeTLBfs to ${TLBFS_DIR}..."
+    sudo mkdir -p ${TLBFS_DIR}
+    sudo mount -t hugetlbfs none ${TLBFS_DIR}
+fi
+
+#################################################################
+## Configuring HugePages
+echo
+echo "Configuring ${NB_HUGEPAGES} HugePages..."
+sudo -s bash -c "echo ${NB_HUGEPAGES} > /proc/sys/vm/nr_hugepages"

--- a/examples/monitoring/VROUTER1/20.compile-vrouter.sh
+++ b/examples/monitoring/VROUTER1/20.compile-vrouter.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+##
+## Compile vRouter/DPDK Script
+## Copyright (c) 2014 Semihalf. All rights reserved.
+##
+
+. 00.config.sh
+
+(cd ${CONTRAIL_DIR} && scons vrouter --optimization=${OPTIMIZATION})

--- a/examples/monitoring/VROUTER1/30.bind-if.sh
+++ b/examples/monitoring/VROUTER1/30.bind-if.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+##
+## Bind Interfaces on VROUTER1
+## Copyright (c) 2014 Semihalf. All rights reserved.
+##
+
+. 00.config.sh
+
+#################################################################
+## Shutdown Linux Interfaces
+sudo ifconfig ${VROUTER1_2_IF} down
+
+#################################################################
+## Load Kernel Modules
+sudo modprobe uio
+sudo insmod ${DPDK_DIR}/build/kmod/rte_kni.ko
+sudo insmod ${DPDK_DIR}/build/kmod/igb_uio.ko
+
+#################################################################
+## Re-bind NICs to DPDK Drivers
+sudo -E ${BIND} -b igb_uio ${VROUTER1_1_PCI}
+sudo -E ${BIND} --status

--- a/examples/monitoring/VROUTER1/40.start-vrouter.sh
+++ b/examples/monitoring/VROUTER1/40.start-vrouter.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+##
+## Start vRouter
+## Copyright (c) 2014 Semihalf. All rights reserved.
+##
+
+. 00.config.sh
+
+export RTE_SDK="${DPDK_DIR}"
+sudo -E ${VROUTER} --no-daemon

--- a/examples/monitoring/VROUTER1/50.start-mon.sh
+++ b/examples/monitoring/VROUTER1/50.start-mon.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+##
+## Start Monitoring Script
+##
+
+. 00.config.sh
+
+#################################################################
+## Add Interfaces
+#sudo ${VIF} --add vm1 --mac ${VM1_MAC} --type virtual --vrf 0 --id 0
+sudo ${VIF} --add ${VROUTER1_1_PCI_DBDF} --mac ${VROUTER1_1_MAC} \
+    --type physical --vrf 0 --id 1 --pci
+sudo ${VIF} --add ${VROUTER1_MON0} --type monitoring --vif 1 --id 2
+sudo ${VIF} --add ${VROUTER1_MON1} --type monitoring --vif 1 --id 3
+sudo ${VIF} --list
+
+## Configure interfaces up
+sudo ifconfig ${VROUTER1_MON0} up
+sudo ifconfig ${VROUTER1_MON1} up
+
+## Start tcpdump
+sudo tcpdump -i ${VROUTER1_MON0} -n

--- a/examples/monitoring/VROUTER1/90.unbind-if.sh
+++ b/examples/monitoring/VROUTER1/90.unbind-if.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+##
+## Unbind Interfaces on vRouter 1
+## Copyright (c) 2014 Semihalf. All rights reserved.
+##
+
+. 00.config.sh
+
+#################################################################
+## Re-bind Interfaces to Linux Driver
+sudo -E ${BIND} -b ${VROUTER1_1_DRV} ${VROUTER1_1_PCI}
+sudo -E ${BIND} --status
+
+#################################################################
+## Remove Kernel Modules
+sudo rmmod rte_kni.ko
+sudo rmmod igb_uio.ko
+
+#################################################################
+## Configure Linux Interfaces
+sudo ifconfig ${VROUTER1_1_IF} ${VROUTER1_1_DEF_IP} netmask 255.255.255.0 up
+sudo ifconfig ${VROUTER1_1_IF}

--- a/include/vr_dpdk.h
+++ b/include/vr_dpdk.h
@@ -255,6 +255,8 @@ struct vr_dpdk_global {
     struct vr_interface *vhosts[VR_MAX_INTERFACES];
     /* Table of ethdevs */
     struct vr_dpdk_ethdev ethdevs[RTE_MAX_ETHPORTS];
+    /* Table of monitoring redirections (for tcpdump) */
+    uint8_t monitorings[VR_MAX_INTERFACES];
 };
 
 extern struct vr_dpdk_global vr_dpdk;

--- a/include/vr_dpdk.h
+++ b/include/vr_dpdk.h
@@ -415,6 +415,10 @@ vr_dpdk_lcore_flush(struct vr_dpdk_lcore *lcore)
     }
     vr_dpdk_packet_tx();
 }
+/* Send a burst of vr_packets to vRouter */
+void
+vr_dpdk_packets_vroute(struct vr_interface *vif,
+    struct vr_packet *pkts[VR_DPDK_MAX_BURST_SZ], uint32_t nb_pkts);
 
 
 /*

--- a/include/vr_interface.h
+++ b/include/vr_interface.h
@@ -24,7 +24,8 @@
 #define VIF_TYPE_VIRTUAL_VLAN       6
 #define VIF_TYPE_STATS              7
 #define VIF_TYPE_VLAN               8
-#define VIF_TYPE_MAX                9
+#define VIF_TYPE_MONITORING         9
+#define VIF_TYPE_MAX               10
 
 #define vif_is_virtual(vif)         ((vif->vif_type == VIF_TYPE_VIRTUAL) ||\
                                         (vif->vif_type == VIF_TYPE_VIRTUAL_VLAN))
@@ -66,6 +67,11 @@
 #define VIF_FLAG_PMD                0x400
 /* The physical interface supports hardware filtering */
 #define VIF_FLAG_FILTERING_OFFLOAD  0x800
+/*
+ * The interface is being monitored,
+ * so we copy all the packets to another interface
+ */
+#define VIF_FLAG_MONITORED          0x1000
 
 #define VIF_TRANSPORT_VIRTUAL       0
 #define VIF_TRANSPORT_ETH           1

--- a/utils/vifdump
+++ b/utils/vifdump
@@ -1,0 +1,66 @@
+#!/bin/bash
+##
+## vRouter/DPDK tcpdump
+##
+
+MON_IF_NAME="mon"
+VR_MAX_INTERFACES=63
+MON_TYPE="monitoring"
+
+usage () {
+    echo "vRouter/DPDK tcmpdump"
+    echo "Usage: ${0##*/} <vif index> [tcpdump arguments]"
+    echo "Example:"
+    echo "      ${0##*/} 1 -n"
+    exit 1
+}
+
+error () {
+    echo "${0##*/} error: $1"
+    exit 1
+}
+
+
+if [ $# -lt 1 ]; then
+    usage
+fi
+
+MONITORED_VIF_ID=${1}; shift
+
+## find free monitoring interface ID
+MON_IF_ID=0
+while true; do
+    if ! ifconfig ${MON_IF_NAME}${MON_IF_ID} &>/dev/null; then
+        break
+    fi
+    MON_IF_ID=$((${MON_IF_ID} + 1))
+done
+
+## find free monitoring vif index
+MON_VIF_ID=$((${VR_MAX_INTERFACES} - ${MON_IF_ID}))
+while true; do
+    if ! vif --list | grep "^vif0/${MON_VIF_ID}\b" &>/dev/null; then
+        break
+    fi
+    MON_VIF_ID=$((${MON_VIF_ID} - 1))
+done
+
+vif --add ${MON_IF_NAME}${MON_IF_ID} --type ${MON_TYPE} --vif ${MONITORED_VIF_ID} \
+    --id ${MON_VIF_ID}
+
+## wait for monitoring interface to appear
+WAIT=10
+while ! ifconfig ${MON_IF_NAME}${MON_IF_ID} &>/dev/null; do
+    WAIT=$((${WAIT} - 1))
+    if [ "${WAIT}" = "0" ]; then
+        error "no interface ${MON_IF_NAME}${MON_IF_ID}"
+    fi
+done
+
+ifconfig ${MON_IF_NAME}${MON_IF_ID} up
+
+## set signal handler
+trap "echo ${0##*/}: deleting vif ${MON_VIF_ID}... && vif --delete ${MON_VIF_ID}" SIGINT
+
+## run tcpdump with the rest of arguments
+tcpdump -i ${MON_IF_NAME}${MON_IF_ID} $*


### PR DESCRIPTION
vif --add mon0 --type monitoring --vif <vif_idx> --id 10
ifconfig mon0 up
tcpdump -i mon0

Example of vif --list:
vif0/1      PMD: vhost0
            Type:Host HWaddr:0c:c4:7a:16:33:9f IPaddr:172.16.0.2
            Vrf:0 Flags:L3Mon MTU:1514 Ref:11
            RX packets:2853  bytes:1237734 errors:6
            TX packets:2241  bytes:532229 errors:0

vif0/10     Monitoring: for vif0/1
            Type:Monitoring HWaddr:02:00:00:00:00:01 
            Vrf:0 Flags:L3L2 MTU:1514 Ref:7
            RX packets:0  bytes:0 errors:0
            TX packets:0  bytes:0 errors:0

TODO:
- wrapping script
- interface deletion
