### PR TITLE
Another implementation of ring allocation/deallocation.

### DIFF
--- a/dpdk/vr_dpdk_ringdev.c
+++ b/dpdk/vr_dpdk_ringdev.c
@@ -186,7 +186,7 @@ vr_dpdk_ring_tx_queue_init(unsigned lcore_id, struct vr_interface *vif,
     return tx_queue;
 
 error:
-    RTE_LOG(ERR, VROUTER, "\terror initializing ring TX queue for device % "
+    RTE_LOG(ERR, VROUTER, "\terror initializing ring TX queue for device %"
         PRIu8 "\n", port_id);
     return NULL;
 }

--- a/dpdk/vr_dpdk_virtio.c
+++ b/dpdk/vr_dpdk_virtio.c
@@ -16,6 +16,8 @@
 #include "qemu_uvhost.h"
 #include "vr_uvhost_client.h"
 
+#include <rte_malloc.h>
+
 void *vr_dpdk_vif_clients[VR_MAX_INTERFACES];
 vr_dpdk_virtioq_t vr_dpdk_virtio_rxqs[VR_MAX_INTERFACES][RTE_MAX_LCORE];
 vr_dpdk_virtioq_t vr_dpdk_virtio_txqs[VR_MAX_INTERFACES][RTE_MAX_LCORE];

--- a/dpdk/vr_dpdk_virtio.c
+++ b/dpdk/vr_dpdk_virtio.c
@@ -76,7 +76,7 @@ dpdk_virtio_rx_queue_release(unsigned lcore_id, struct vr_interface *vif)
     dpdk_ring_to_push_remove(rx_queue_params->qp_ring.host_lcore_id,
             rx_queue_params->qp_ring.ring_p);
 
-    dpdk_ring_free(rx_queue_params->qp_ring.ring_p);
+    rte_free(rx_queue_params->qp_ring.ring_p);
 
     /* reset the queue */
     memset(rx_queue->q_queue_h, 0, sizeof(vr_dpdk_virtioq_t));
@@ -115,9 +115,7 @@ vr_dpdk_virtio_rx_queue_init(unsigned int lcore_id, struct vr_interface *vif,
         goto error;
 
     vr_dpdk_virtio_rxqs[vif_idx][queue_id].vdv_pring =
-        dpdk_ring_allocate(lcore_id, vif_idx, queue_id, ring_name,
-            VR_DPDK_VIRTIO_TX_RING_SZ, rte_socket_id(),
-            RING_F_SP_ENQ | RING_F_SC_DEQ);
+        vr_dpdk_ring_allocate(lcore_id, ring_name, VR_DPDK_VIRTIO_TX_RING_SZ);
     if (vr_dpdk_virtio_rxqs[vif_idx][queue_id].vdv_pring == NULL)
         goto error;
 
@@ -153,7 +151,7 @@ vr_dpdk_virtio_rx_queue_init(unsigned int lcore_id, struct vr_interface *vif,
     return rx_queue;
 
 error:
-    RTE_LOG(INFO, VROUTER, "\tcreating lcore %u RX ring for queue %u vif %u\n",
+    RTE_LOG(ERR, VROUTER, "\terror creating lcore %u RX ring for queue %u vif %u\n",
         lcore_id, queue_id, vif_idx);
     return NULL;
 }

--- a/include/vr_dpdk.h
+++ b/include/vr_dpdk.h
@@ -486,12 +486,8 @@ int dpdk_netlink_io(void);
  */
 /* Allocates a new ring */
 struct rte_ring *
-dpdk_ring_allocate(unsigned host_lcore_id, unsigned vif_idx,
-    unsigned for_lcore_id, char *ring_name, unsigned vr_dpdk_tx_ring_sz,
-    int socket, int flags);
-/* deallocate the ring */
-void
-dpdk_ring_free(struct rte_ring *ring);
+vr_dpdk_ring_allocate(unsigned host_lcore_id, char *ring_name,
+    unsigned vr_dpdk_tx_ring_sz);
 /* Init ring RX queue */
 struct vr_dpdk_queue *
 vr_dpdk_ring_rx_queue_init(unsigned lcore_id, struct vr_interface *vif,

--- a/include/vr_dpdk.h
+++ b/include/vr_dpdk.h
@@ -484,6 +484,14 @@ int dpdk_netlink_io(void);
 /*
  * vr_dpdk_ringdev.c
  */
+/* Allocates a new ring */
+struct rte_ring *
+dpdk_ring_allocate(unsigned host_lcore_id, unsigned vif_idx,
+    unsigned for_lcore_id, char *ring_name, unsigned vr_dpdk_tx_ring_sz,
+    int socket, int flags);
+/* deallocate the ring */
+void
+dpdk_ring_free(struct rte_ring *ring);
 /* Init ring RX queue */
 struct vr_dpdk_queue *
 vr_dpdk_ring_rx_queue_init(unsigned lcore_id, struct vr_interface *vif,


### PR DESCRIPTION
Memory for a ring is allocated manually using rte_malloc_socket()
and initialized with rte_ring_init(). This approach lets to deallocate
memory with rte_free(), what was impossible while creating rings with
rte_ring_create(), where memory was allocated with rte_memzone_reserve().

Rings are dealocated with dpdk_ring_free(), so there is no need to implement
a mechanism of re-using the memory. It's just allocated once again if needed.

dpdk_ring_allocate() has been rewritten to be a generic function.
