### PR TITLE
Start vRouter on four cores by default.

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -21,6 +21,7 @@ env.Replace(CPPPATH = '#vrouter/include')
 env.Append(CPPPATH = [env['TOP'] + '/vrouter/sandesh/gen-c'])
 env.Append(CPPPATH = ['#tools'])
 env.Append(CPPPATH = ['#tools/sandesh/library/c'])
+env.Append(CPPPATH = ['#third_party/dpdk/build/include'])
 
 vr_root = './'
 makefile = vr_root + 'Makefile'
@@ -64,7 +65,8 @@ if sys.platform != 'darwin':
     buildinfo = env.GenerateBuildInfoCCode(target = ['vr_buildinfo.c'],
             source = [], path = dp_dir + 'dp-core')
 
-    subdirs = ['linux', 'include', 'dp-core', 'host', 'sandesh', 'utils', 'uvrouter', 'test']
+    subdirs = ['linux', 'include', 'dp-core', 'host', 'sandesh', \
+                            'utils', 'uvrouter', 'test', 'dpdk']
     for sdir in  subdirs:
         env.SConscript(sdir + '/SConscript',
                        exports='VRouterEnv',
@@ -79,6 +81,7 @@ if sys.platform != 'darwin':
     make_cmd += ' SANDESH_EXTRA_HEADER_PATH=' + Dir('#tools/').abspath
     if 'vrouter' in COMMAND_LINE_TARGETS:
         BUILD_TARGETS.append('vrouter/uvrouter')
+        BUILD_TARGETS.append('vrouter/dpdk')
         BUILD_TARGETS.append('vrouter/utils')
 
     kern = env.Command('vrouter.ko', None, make_cmd)

--- a/SConscript
+++ b/SConscript
@@ -15,13 +15,15 @@ AddOption('--system-header-path', dest = 'system-header-path', action='store',
 
 env = DefaultEnvironment().Clone()
 VRouterEnv = env
+dpdk_exists = os.path.isdir('../third_party/dpdk')
 
 # Include paths
 env.Replace(CPPPATH = '#vrouter/include')
 env.Append(CPPPATH = [env['TOP'] + '/vrouter/sandesh/gen-c'])
 env.Append(CPPPATH = ['#tools'])
 env.Append(CPPPATH = ['#tools/sandesh/library/c'])
-env.Append(CPPPATH = ['#third_party/dpdk/build/include'])
+if dpdk_exists:
+    env.Append(CPPPATH = ['#third_party/dpdk/build/include'])
 
 vr_root = './'
 makefile = vr_root + 'Makefile'
@@ -65,8 +67,13 @@ if sys.platform != 'darwin':
     buildinfo = env.GenerateBuildInfoCCode(target = ['vr_buildinfo.c'],
             source = [], path = dp_dir + 'dp-core')
 
-    subdirs = ['linux', 'include', 'dp-core', 'host', 'sandesh', \
+    if dpdk_exists:
+        subdirs = ['linux', 'include', 'dp-core', 'host', 'sandesh', \
                             'utils', 'uvrouter', 'test', 'dpdk']
+    else:
+        subdirs = ['linux', 'include', 'dp-core', 'host', 'sandesh', \
+                            'utils', 'uvrouter', 'test']
+
     for sdir in  subdirs:
         env.SConscript(sdir + '/SConscript',
                        exports='VRouterEnv',
@@ -81,7 +88,8 @@ if sys.platform != 'darwin':
     make_cmd += ' SANDESH_EXTRA_HEADER_PATH=' + Dir('#tools/').abspath
     if 'vrouter' in COMMAND_LINE_TARGETS:
         BUILD_TARGETS.append('vrouter/uvrouter')
-        BUILD_TARGETS.append('vrouter/dpdk')
+        if dpdk_exists:
+            BUILD_TARGETS.append('vrouter/dpdk')
         BUILD_TARGETS.append('vrouter/utils')
 
     kern = env.Command('vrouter.ko', None, make_cmd)

--- a/dp-core/vr_bridge.c
+++ b/dp-core/vr_bridge.c
@@ -52,7 +52,7 @@ struct vr_bridge_entry *vr_find_free_bridge_entry(unsigned int, char *);
 
 
 static bool
-bridge_entry_valid(vr_htable_t htable, vr_hentry_t hentry, 
+bridge_entry_valid(vr_htable_t htable, vr_hentry_t hentry,
                                               unsigned int index)
 {
     struct vr_bridge_entry *be = (struct vr_bridge_entry *)hentry;
@@ -144,7 +144,7 @@ static int
 bridge_table_add(struct vr_rtable * _unused, struct vr_route_req *rt)
 {
     int ret;
-    
+
     if (!vn_rtable)
         return -EINVAL;
 
@@ -171,7 +171,7 @@ static void
 bridge_table_entry_free(vr_htable_t table, vr_hentry_t hentry,
         unsigned int index, void *data)
 {
-    struct vr_bridge_entry *be = (struct vr_bridge_entry *)hentry; 
+    struct vr_bridge_entry *be = (struct vr_bridge_entry *)hentry;
     if (!be)
         return;
 
@@ -312,7 +312,7 @@ __bridge_table_dump(struct vr_message_dumper *dumper)
 
     for(i = 0; i < (vr_bridge_entries + vr_bridge_oentries); i++) {
         be = (struct vr_bridge_entry *) vr_get_hentry_by_index(vn_rtable, i);
-        if (!be) 
+        if (!be)
             continue;
         if (be->be_flags & VR_BE_VALID_FLAG) {
             if (be->be_key.be_vrf_id != req->rtr_req.rtr_vrf_id)
@@ -372,14 +372,14 @@ bridge_table_init(struct vr_rtable *rtable, struct rtable_fspec *fs)
 
     rtable->algo_data = vr_htable_create(vr_bridge_entries,
             vr_bridge_oentries, sizeof(struct vr_bridge_entry),
-            sizeof(struct vr_bridge_entry_key), bridge_entry_valid);  
+            sizeof(struct vr_bridge_entry_key), bridge_entry_valid);
 
     if (!rtable->algo_data)
-        return vr_module_error(-ENOMEM, __FUNCTION__, __LINE__, 
+        return vr_module_error(-ENOMEM, __FUNCTION__, __LINE__,
                 vr_bridge_entries);
 
     /* Max VRF's does not matter as Bridge table is not per VRF. But
-     * still this can be maintained in table 
+     * still this can be maintained in table
      */
     rtable->algo_max_vrfs = fs->rtb_max_vrfs;
     rtable->algo_add = bridge_table_add;

--- a/dp-core/vr_btable.c
+++ b/dp-core/vr_btable.c
@@ -56,7 +56,7 @@ vr_btable_get_address(struct vr_btable *table, unsigned int offset)
         if (!partition)
             break;
 
-        if (offset >= partition->vb_offset && 
+        if (offset >= partition->vb_offset &&
                 offset < partition->vb_offset + partition->vb_mem_size)
             return (char *)table->vb_mem[i] + (offset - partition->vb_offset);
     }
@@ -72,7 +72,8 @@ vr_btable_free(struct vr_btable *table)
     if (!table)
         return;
 
-    if (table->vb_mem) {
+    if (!(table->vb_flags & VB_FLAG_MEMORY_ATTACHED) &&
+            (table->vb_mem)) {
         for (i = 0; i < table->vb_partitions; i++) {
             if (table->vb_mem[i]) {
                 vr_page_free(table->vb_mem[i],
@@ -80,12 +81,6 @@ vr_btable_free(struct vr_btable *table)
             }
         }
     }
-
-    if (table->vb_table_info)
-        vr_free(table->vb_table_info);
-
-    if (table->vb_mem)
-        vr_free(table->vb_mem);
 
     vr_free(table);
 
@@ -96,7 +91,7 @@ struct vr_btable *
 vr_btable_alloc(unsigned int num_entries, unsigned int entry_size)
 {
     unsigned int i = 0, num_parts, remainder;
-    unsigned int total_parts;
+    unsigned int total_parts, alloc_size;
     uint64_t total_mem;
     struct vr_btable *table;
     unsigned int offset = 0;
@@ -128,15 +123,18 @@ vr_btable_alloc(unsigned int num_entries, unsigned int entry_size)
     if (!total_parts)
         return NULL;
 
-    table = vr_zalloc(sizeof(*table));
+    alloc_size = sizeof(*table) + (total_parts * (sizeof(void *))) +
+        (total_parts * sizeof(struct vr_btable_partition));
+
+    table = vr_zalloc(alloc_size);
     if (!table)
         return NULL;
 
-    table->vb_mem = vr_zalloc(total_parts * sizeof(void *));
-    table->vb_table_info = vr_zalloc(total_parts *
-            sizeof(struct vr_btable_partition));
-    if (!table->vb_mem || !table->vb_table_info)
-        goto exit_alloc;
+    table->vb_alloc_limit = VR_SINGLE_ALLOC_LIMIT;
+    table->vb_mem = (void **)(table + 1);
+    table->vb_table_info =
+        (struct vr_btable_partition *)((unsigned char *)table->vb_mem +
+                (total_parts * sizeof(void *)));
 
     if (num_parts) {
         for (i = 0; i < num_parts; i++) {
@@ -168,3 +166,61 @@ exit_alloc:
     vr_btable_free(table);
     return NULL;
 }
+
+struct vr_btable *
+vr_btable_attach(struct iovec *iov, unsigned int iov_len,
+        unsigned short esize)
+{
+    unsigned int i, alloc_size;
+    unsigned int offset = 0, total_size = 0;
+    struct vr_btable *table;
+
+    if (!iov || !iov_len)
+        return NULL;
+
+    if (iov[0].iov_len % esize)
+        return NULL;
+
+    alloc_size = sizeof(struct vr_btable *);
+    alloc_size += (sizeof(void *) * iov_len);
+    alloc_size += (sizeof(struct vr_btable_partition) * iov_len);
+
+
+    table = (struct vr_btable *)vr_zalloc(alloc_size);
+    if (!table)
+        return NULL;
+
+    table->vb_esize = esize;
+    table->vb_partitions = iov_len;
+    table->vb_alloc_limit = iov->iov_len;
+    table->vb_mem = (void **)(table + 1);
+    table->vb_table_info =
+        (struct vr_btable_partition *)((unsigned char *)table->vb_mem +
+                (iov_len * sizeof(void *)));
+
+    for (i = 0; i < iov_len; i++) {
+        table->vb_mem[i] = iov[i].iov_base;
+        if ((iov[i].iov_len != table->vb_alloc_limit) &&
+                (i != (iov_len - 1)))
+            goto error;
+
+        table->vb_table_info[i].vb_mem_size = iov[i].iov_len;
+        table->vb_table_info[i].vb_offset = offset;
+
+        offset += iov[i].iov_len;
+        total_size += iov[i].iov_len;
+    }
+
+    if (total_size % esize)
+        goto error;
+
+    table->vb_entries = (total_size / esize);
+    table->vb_flags |= VB_FLAG_MEMORY_ATTACHED;
+
+    return table;
+
+error:
+    vr_btable_free(table);
+    return NULL;
+}
+

--- a/dp-core/vr_fragment.c
+++ b/dp-core/vr_fragment.c
@@ -81,7 +81,7 @@ vr_fragment_add(struct vrouter *router, unsigned short vrf, struct vr_ip *iph,
     index = (hash % FRAG_TABLE_ENTRIES) * FRAG_TABLE_BUCKETS;
     for (i = 0; i < FRAG_TABLE_BUCKETS; i++) {
         fe = fragment_entry_get(router, index + i);
-        if (fe && !fe->f_dip  && fragment_entry_alloc(fe)) {
+        if (fe && !fe->f_dip && fragment_entry_alloc(fe)) {
             fragment_entry_set(fe, vrf, iph, sport, dport);
             break;
         } else {
@@ -112,7 +112,7 @@ vr_fragment_add(struct vrouter *router, unsigned short vrf, struct vr_ip *iph,
 
 struct vr_fragment *
 vr_fragment_get(struct vrouter *router, unsigned short vrf, struct vr_ip *iph)
-{   
+{
     unsigned int hash, index, i;
     struct vr_fragment_key key;
     struct vr_fragment *fe;
@@ -263,7 +263,7 @@ vr_fragment_table_scanner_exit(struct vrouter *router)
 
 void
 vr_fragment_table_exit(struct vrouter *router)
-{   
+{
     vr_fragment_table_scanner_exit(router);
 
     if (router->vr_fragment_table)

--- a/dp-core/vr_htable.c
+++ b/dp-core/vr_htable.c
@@ -18,21 +18,21 @@ struct vr_htable {
     is_hentry_valid is_valid_entry;
 };
 
-void 
-vr_htable_trav(vr_htable_t htable, unsigned int marker, htable_trav_cb cb, 
+void
+vr_htable_trav(vr_htable_t htable, unsigned int marker, htable_trav_cb cb,
                                                                 void *data)
 {
     struct vr_htable *table = (struct vr_htable *)htable;
     vr_hentry_t ent;
     unsigned int i;
-    
+
     if (!table || !cb)
         return;
 
     if (marker < table->hentries) {
         for (i = marker; i < table->hentries; i++) {
             ent = vr_btable_get(table->htable, i);
-            if(ent && table->is_valid_entry(htable, ent, i) == true) 
+            if(ent && table->is_valid_entry(htable, ent, i) == true)
                 cb(htable, ent, i, data);
         }
     }
@@ -41,8 +41,8 @@ vr_htable_trav(vr_htable_t htable, unsigned int marker, htable_trav_cb cb,
     if (marker < table->oentries) {
         for (i = marker; i < table->oentries; i++) {
             ent = vr_btable_get(table->htable, i);
-            if(ent && table->is_valid_entry(htable, ent, 
-                        (i + table->hentries)) == true) 
+            if(ent && table->is_valid_entry(htable, ent,
+                        (i + table->hentries)) == true)
                 cb(htable, ent, (i + table->hentries), data);
         }
     }
@@ -122,7 +122,7 @@ vr_find_duplicate_hentry_index(vr_htable_t htable, vr_hentry_t hentry)
         ent = vr_btable_get(table->htable, ind);
         if (table->is_valid_entry(htable, ent, ind) == false)
             continue;
-        if ((ent == hentry) || (memcmp(ent, hentry, table->key_size) != 0)) 
+        if ((ent == hentry) || (memcmp(ent, hentry, table->key_size) != 0))
             continue;
         return ind;
     }
@@ -207,7 +207,7 @@ vr_htable_delete(vr_htable_t htable)
 }
 
 vr_htable_t
-vr_htable_create(unsigned int entries, unsigned int oentries, 
+vr_htable_create(unsigned int entries, unsigned int oentries,
         unsigned int entry_size, unsigned int key_size,
         is_hentry_valid is_valid_entry)
 {
@@ -228,7 +228,7 @@ vr_htable_create(unsigned int entries, unsigned int oentries,
                                        sizeof(struct vr_htable));
         return NULL;
     }
-    
+
     table->htable = vr_btable_alloc(entries, entry_size);
     if (!table->htable) {
         vr_module_error(-ENOMEM, __FUNCTION__, __LINE__, entries);

--- a/dp-core/vr_index_table.c
+++ b/dp-core/vr_index_table.c
@@ -34,7 +34,7 @@ vr_stride_empty(void **ptr, unsigned int cnt)
 }
 
 /* Default print function */
-static int 
+static int
 print_ind(unsigned int index, void *data, void *udata)
 {
     vr_printf("Index %d Data 0x%p\n", index, data);
@@ -49,7 +49,7 @@ get_page_shift(void)
 }
 #else
 static unsigned int
-get_page_shift(void) 
+get_page_shift(void)
 {
     return ffs(getpagesize());
 }
@@ -58,16 +58,16 @@ get_page_shift(void)
 
 
 static int
-__vr_itable_del(struct vr_itbl *table, unsigned int index, 
+__vr_itable_del(struct vr_itbl *table, unsigned int index,
                         void **ptr, unsigned int cnt, void **old)
 {
     unsigned int id;
 
     if (cnt == table->stride_cnt-1) {
-        id = (index >> table->stride_shift[cnt]) & (table->stride_len[cnt] - 1); 
+        id = (index >> table->stride_shift[cnt]) & (table->stride_len[cnt] - 1);
         *old = ptr[id];
 
-        /* 
+        /*
          * IF an entry exists to delete, mark it null. If the whole
          * stride is null, delete the stride itself
          */
@@ -80,15 +80,15 @@ __vr_itable_del(struct vr_itbl *table, unsigned int index,
         }
         return 0;
     }
-    
+
     if ((cnt < (table->stride_cnt - 1)) && ptr) {
-        id = (index >> table->stride_shift[cnt]) & (table->stride_len[cnt] - 1); 
-        if (ptr[id] && __vr_itable_del(table, index, (void **)(ptr[id]), 
+        id = (index >> table->stride_shift[cnt]) & (table->stride_len[cnt] - 1);
+        if (ptr[id] && __vr_itable_del(table, index, (void **)(ptr[id]),
                                             (cnt+1), old) == 1) {
 
-            /* 
-             * If a later stride is deleted, check for the 
-             * earliter stride as well 
+            /*
+             * If a later stride is deleted, check for the
+             * earliter stride as well
              */
             ptr[id] = NULL;
             if (vr_stride_empty(ptr, table->stride_len[cnt]) == 1) {
@@ -107,8 +107,8 @@ __vr_itable_del(struct vr_itbl *table, unsigned int index,
     return 0;
 }
 
-static int 
-__vr_itable_dump(struct vr_itbl *table, vr_itable_trav_cb_t func, void **ptr, 
+static int
+__vr_itable_dump(struct vr_itbl *table, vr_itable_trav_cb_t func, void **ptr,
         unsigned int cnt, unsigned int index, unsigned int marker, void *udata)
 {
     unsigned int i, j;
@@ -136,11 +136,11 @@ __vr_itable_dump(struct vr_itbl *table, vr_itable_trav_cb_t func, void **ptr,
         return res;
     }
 
-    for (i = 0; i < table->stride_len[cnt]; i++) { 
+    for (i = 0; i < table->stride_len[cnt]; i++) {
 
         /* Rectursively call all strides */
         if (ptr[i]) {
-            res = __vr_itable_dump(table, func, (void **)ptr[i], (cnt + 1), 
+            res = __vr_itable_dump(table, func, (void **)ptr[i], (cnt + 1),
                     (index | (i << table->stride_shift[cnt])), marker, udata);
 
             /* No more traversal if upper stride stopped it */
@@ -154,7 +154,7 @@ __vr_itable_dump(struct vr_itbl *table, vr_itable_trav_cb_t func, void **ptr,
 }
 
 static void
-__vr_itable_exit(struct vr_itbl *table, vr_itable_del_cb_t func, 
+__vr_itable_exit(struct vr_itbl *table, vr_itable_del_cb_t func,
                         void **ptr, unsigned int cnt, unsigned int index)
 {
     unsigned int i, j;
@@ -182,9 +182,9 @@ __vr_itable_exit(struct vr_itbl *table, vr_itable_del_cb_t func,
         return;
     }
 
-    for (i = 0; i < table->stride_len[cnt]; i++) { 
+    for (i = 0; i < table->stride_len[cnt]; i++) {
         if (ptr[i]) {
-            __vr_itable_exit(table, func, (void **)ptr[i], (cnt + 1), 
+            __vr_itable_exit(table, func, (void **)ptr[i], (cnt + 1),
                     (index | (i << table->stride_shift[cnt])));
 
             /* Upper strides are deleted. Delete the current */
@@ -207,7 +207,7 @@ vr_print_table_struct(vr_itable_t t)
 {
     struct vr_itbl *table = (struct vr_itbl *)t;
     unsigned int i;
-    
+
     if (!table) {
         return;
     }
@@ -223,7 +223,7 @@ vr_print_table_struct(vr_itable_t t)
 }
 
 int
-vr_itable_trav(vr_itable_t t, vr_itable_trav_cb_t func, 
+vr_itable_trav(vr_itable_t t, vr_itable_trav_cb_t func,
                                      unsigned int marker, void *udata)
 {
     struct vr_itbl *table = (struct vr_itbl *) t;
@@ -238,7 +238,7 @@ vr_itable_trav(vr_itable_t t, vr_itable_trav_cb_t func,
         func = print_ind;
     }
 
-    return  __vr_itable_dump(table, func, ptr, 0, 0, marker, udata);
+    return __vr_itable_dump(table, func, ptr, 0, 0, marker, udata);
 }
 
 void *
@@ -271,7 +271,7 @@ vr_itable_get(vr_itable_t t, unsigned int index)
 
     /* Go till last stride as long as data exists */
     for (i = 0, ptr = table->data; (i < table->stride_cnt) && ptr; i++) {
-        id = (index >> table->stride_shift[i]) & (table->stride_len[i] - 1); 
+        id = (index >> table->stride_shift[i]) & (table->stride_len[i] - 1);
         ptr = (void **)(ptr[id]);
     }
 
@@ -279,8 +279,8 @@ vr_itable_get(vr_itable_t t, unsigned int index)
 }
 
 /*
- * Insert an entry into index table. 
- * Returns the old entry at that index in success case. The old entry can be null. 
+ * Insert an entry into index table.
+ * Returns the old entry at that index in success case. The old entry can be null.
  * Incase of error returns ((void *)-1)
  */
 
@@ -297,8 +297,8 @@ vr_itable_set(vr_itable_t t, unsigned int index, void *data)
         return VR_ITABLE_ERR_PTR;
     }
 
-    if (index & (~(((0x1 << (table->index_len - 1)) - 1) | 
-				(0x1 << (table->index_len - 1 ))))) {
+    if (index & (~(((0x1 << (table->index_len - 1)) - 1) |
+        (0x1 << (table->index_len - 1 ))))) {
         vr_printf("Index %x has more bits than %d Ignoring MSB\n",
                 index, table->index_len);
     }
@@ -312,7 +312,7 @@ vr_itable_set(vr_itable_t t, unsigned int index, void *data)
     ptr = table->data;
 
     for (i = 0; i < table->stride_cnt - 1; i++) {
-        id = (index >> table->stride_shift[i]) & (table->stride_len[i] - 1); 
+        id = (index >> table->stride_shift[i]) & (table->stride_len[i] - 1);
 
         if (!ptr[id]) {
             ptr[id] = vr_zalloc(table->stride_len[i + 1] * sizeof(void *));
@@ -326,7 +326,7 @@ vr_itable_set(vr_itable_t t, unsigned int index, void *data)
     }
 
     /* Store the data in the last stride */
-    id = (index >> table->stride_shift[i]) & (table->stride_len[i] - 1); 
+    id = (index >> table->stride_shift[i]) & (table->stride_len[i] - 1);
 
     /* Return the old data */
     old = ptr[id];
@@ -334,7 +334,7 @@ vr_itable_set(vr_itable_t t, unsigned int index, void *data)
     return old;
 }
 
-/* 
+/*
  * Delete the whole index table. After deleting the individual entries
  * Delete all strides. After strides delete table management data as well
  */
@@ -360,10 +360,10 @@ vr_itable_delete(vr_itable_t t, vr_itable_del_cb_t func)
 
 /*
  * index_len - How many bits does index consist of. Max is 32 and any length
- * of bits can be used. 
- * stride_cnt - How many strides user wants. Minimum of 2. 
- * Varable arguments follow to identify how many bits is each stride. 
- * 
+ * of bits can be used.
+ * stride_cnt - How many strides user wants. Minimum of 2.
+ * Varable arguments follow to identify how many bits is each stride.
+ *
  */
 
 vr_itable_t
@@ -395,7 +395,7 @@ vr_itable_create(unsigned int index_len, unsigned int stride_cnt, ...)
     table->stride_cnt = stride_cnt;
 
     table->stride_shift = vr_zalloc(table->stride_cnt * sizeof(unsigned int));
-    if (!table->stride_shift) { 
+    if (!table->stride_shift) {
         goto fail;
     }
 

--- a/dp-core/vr_interface.c
+++ b/dp-core/vr_interface.c
@@ -31,7 +31,7 @@ struct vr_interface_stats *vif_get_stats(struct vr_interface *, unsigned short);
 struct vr_interface *__vrouter_get_interface_os(struct vrouter *, unsigned int);
 
 extern struct vr_host_interface_ops *vr_host_interface_init(void);
-extern void  vr_host_interface_exit(void);
+extern void vr_host_interface_exit(void);
 extern void vr_host_vif_init(struct vrouter *);
 extern struct vr_interface *vif_bridge_get_sub_interface(vr_htable_t,
         unsigned short, unsigned char *);
@@ -210,7 +210,7 @@ vif_xconnect(struct vr_interface *vif, struct vr_packet *pkt,
         struct vr_forwarding_md *fmd)
 {
     struct vr_interface *bridge;
-    
+
     if (!vif)
         goto free_pkt;
 
@@ -296,13 +296,13 @@ agent_rx(struct vr_interface *vif, struct vr_packet *pkt,
     switch (cmd) {
     case AGENT_CMD_ROUTE:
         /*
-         * XXX 
-         * Packet with command "route" from agent may 
-         * result in flow setup, this breaks the 
+         * XXX
+         * Packet with command "route" from agent may
+         * result in flow setup, this breaks the
          * assumption that all packets for a flow will
          * reach same CPU. Need a better way to handle this
          */
-        agent_vif = __vrouter_get_interface(vrouter_get(0), 
+        agent_vif = __vrouter_get_interface(vrouter_get(0),
                                             ntohs(hdr->hdr_ifindex));
         if (!agent_vif) {
             agent_vif = vif;
@@ -332,7 +332,7 @@ agent_rx(struct vr_interface *vif, struct vr_packet *pkt,
 
         pkt->vp_type = VP_TYPE_AGENT;
         pkt_set_network_header(pkt, pkt->vp_data + sizeof(struct vr_eth));
-        pkt_set_inner_network_header(pkt, 
+        pkt_set_inner_network_header(pkt,
                                      pkt->vp_data + sizeof(struct vr_eth));
         return vif->vif_tx(vif, pkt, &fmd);
 
@@ -666,9 +666,6 @@ vhost_drv_add(struct vr_interface *vif,
         vr_interface_req *vifr __attribute__((unused)))
 {
     int ret = 0;
-
-    if (!vif->vif_os_idx)
-        return -EINVAL;
 
     if (!vif->vif_mtu)
         vif->vif_mtu = 1514;
@@ -1075,7 +1072,7 @@ eth_tx(struct vr_interface *vif, struct vr_packet *pkt,
         m_fmd.fmd_dvrf = vif->vif_vrf;
         vr_mirror(vif->vif_router, vif->vif_mirror_id, pkt, &m_fmd);
     }
-        
+
     ret = hif_ops->hif_tx(vif, pkt);
     if (ret != 0) {
         if (!from_subvif)
@@ -1148,7 +1145,7 @@ eth_drv_add_sub_interface(struct vr_interface *pvif, struct vr_interface *vif)
                 sizeof(struct vr_interface *));
         if (!pvif->vif_sub_interfaces)
             return -ENOMEM;
-        /* 
+        /*
          * we are not going to free this memory, since it is not guaranteed
          * that we will get contiguous memory. so hold on to it for the life
          * time of the interface
@@ -1166,9 +1163,6 @@ eth_drv_add(struct vr_interface *vif,
         vr_interface_req *vifr __attribute__((unused)))
 {
     int ret = 0;
-
-    if (!vif->vif_os_idx)
-        return -EINVAL;
 
     if (!vif->vif_mtu) {
         vif->vif_mtu = 9160;
@@ -1266,6 +1260,10 @@ static struct vr_interface_driver vif_drivers[VIF_TYPE_MAX] = {
     [VIF_TYPE_STATS] = {
         .drv_add                    =   eth_drv_add,
         .drv_delete                 =   eth_drv_del,
+    },
+    [VIF_TYPE_MONITORING] = {
+        .drv_add                    =   vhost_drv_add,
+        .drv_delete                 =   vhost_drv_del,
     },
 };
 
@@ -1447,7 +1445,7 @@ vrouter_set_rewrite(struct vr_interface *vif)
     unsigned char *ptr;
 
     ptr = vif->vif_rewrite;
-    /* 
+    /*
      * the DMAC would already have been set as part of
      * driver add
      */
@@ -1525,7 +1523,7 @@ vif_detach(struct vr_interface *vif)
     if (vif_drivers[vif->vif_type].drv_delete)
         vif_drivers[vif->vif_type].drv_delete(vif);
 
-    return; 
+    return;
 }
 
 static void
@@ -1677,10 +1675,27 @@ vr_interface_change(struct vr_interface *vif, vr_interface_req *req)
     return 0;
 }
 
+static bool
+vif_transport_valid(vr_interface_req *req)
+{
+    switch (req->vifr_transport) {
+    case VIF_TRANSPORT_VIRTUAL:
+    case VIF_TRANSPORT_ETH:
+    case VIF_TRANSPORT_PMD:
+    case VIF_TRANSPORT_SOCKET:
+        return true;
+
+    default:
+        break;
+    }
+
+    return false;
+}
+
 int
 vr_interface_add(vr_interface_req *req, bool need_response)
 {
-    int ret;
+    int ret = 0;
     struct vr_interface *vif = NULL;
     struct vrouter *router = vrouter_get(req->vifr_rid);
 
@@ -1690,6 +1705,9 @@ vr_interface_add(vr_interface_req *req, bool need_response)
     }
 
     if (req->vifr_type >= VIF_TYPE_MAX && (ret = -EINVAL))
+        goto generate_resp;
+
+    if (!vif_transport_valid(req))
         goto generate_resp;
 
     vif = __vrouter_get_interface(router, req->vifr_idx);
@@ -1725,25 +1743,27 @@ vr_interface_add(vr_interface_req *req, bool need_response)
     vif->vif_vlan_id = VLAN_ID_INVALID;
     vif->vif_mtu = req->vifr_mtu;
     vif->vif_idx = req->vifr_idx;
+    vif->vif_transport = req->vifr_transport;
     vif->vif_os_idx = req->vifr_os_idx;
     if (req->vifr_os_idx == -1)
         vif->vif_os_idx = 0;
     vif->vif_rid = req->vifr_rid;
     vif->vif_nh_id = (unsigned short)req->vifr_nh_id;
 
-    if ((req->vifr_mac_size != sizeof(vif->vif_mac)) || !req->vifr_mac) {
-        ret = -EINVAL;
-        goto generate_resp;
-    }
+    if (req->vifr_mac) {
+        if (req->vifr_mac_size != sizeof(vif->vif_mac)) {
+            ret = -EINVAL;
+            goto generate_resp;
+        }
 
-    memcpy(vif->vif_mac, req->vifr_mac, sizeof(vif->vif_mac));
-    memcpy(vif->vif_rewrite, req->vifr_mac, sizeof(vif->vif_mac));
+        memcpy(vif->vif_mac, req->vifr_mac, sizeof(vif->vif_mac));
+        memcpy(vif->vif_rewrite, req->vifr_mac, sizeof(vif->vif_mac));
+    }
 
     vif->vif_ip = req->vifr_ip;
 
     if (req->vifr_name) {
-        strncpy(vif->vif_name, req->vifr_name, sizeof(vif->vif_name));
-        vif->vif_name[sizeof(vif->vif_name) - 1] = '\0';
+        strncpy(vif->vif_name, req->vifr_name, sizeof(vif->vif_name) - 1);
     }
 
     /*
@@ -1789,6 +1809,7 @@ vr_interface_make_req(vr_interface_req *req, struct vr_interface *intf)
     req->vifr_vrf = intf->vif_vrf;
     req->vifr_idx = intf->vif_idx;
     req->vifr_rid = intf->vif_rid;
+    req->vifr_transport = intf->vif_transport;
     req->vifr_os_idx = intf->vif_os_idx;
     req->vifr_mtu = intf->vif_mtu;
     if (req->vifr_mac_size && req->vifr_mac)
@@ -1797,6 +1818,10 @@ vr_interface_make_req(vr_interface_req *req, struct vr_interface *intf)
     req->vifr_ip = intf->vif_ip;
 
     req->vifr_ref_cnt = intf->vif_users;
+
+    if (req->vifr_name) {
+        strncpy(req->vifr_name, intf->vif_name, VR_INTERFACE_NAME_LEN - 1);
+    }
 
     if (intf->vif_parent)
         req->vifr_parent_vif_idx = intf->vif_parent->vif_idx;
@@ -2129,12 +2154,12 @@ vr_gro_vif_add(struct vrouter *router, unsigned int os_idx, char *name,
     req->vifr_vrf = 65535;
     req->vifr_idx = idx;
     req->vifr_rid = 0;
+    req->vifr_transport = VIF_TRANSPORT_ETH;
     req->vifr_os_idx = os_idx;
     req->vifr_mtu = 9136;
 
     if (req->vifr_name) {
-        strncpy(req->vifr_name, name, VR_INTERFACE_NAME_LEN);
-        req->vifr_name[VR_INTERFACE_NAME_LEN - 1] = '\0';
+        strncpy(req->vifr_name, name, VR_INTERFACE_NAME_LEN - 1);
     }
 
     ret = vr_interface_add(req, false);

--- a/dp-core/vr_ip_mtrie.c
+++ b/dp-core/vr_ip_mtrie.c
@@ -13,7 +13,7 @@
 #include "vr_datapath.h"
 #include "vr_ip_mtrie.h"
 
-extern struct vr_nexthop *ip4_default_nh; 
+extern struct vr_nexthop *ip4_default_nh;
 
 static struct vr_vrf_stats **mtrie_vrf_stats;
 static struct vr_vrf_stats *invalid_vrf_stats;
@@ -266,7 +266,7 @@ mtrie_free_entry(struct ip_bucket_entry *entry, unsigned int level)
 
     return;
 }
-        
+
 static void
 mtrie_reset_entry(struct ip_bucket_entry *ent, int level,
                 struct vr_nexthop *nh)
@@ -288,8 +288,8 @@ mtrie_reset_entry(struct ip_bucket_entry *ent, int level,
 
     return;
 }
-       
-/* 
+
+/*
  * When adding a route:
  * - descend the tree to the bucket at which the route is significant.
  * (i.e. the bucket corresponding to a prefix >= to the route prefix).
@@ -341,7 +341,7 @@ __mtrie_add(struct ip_mtrie *mtrie, struct vr_route_req *rt)
             continue;
 
         } else {
-            /* 
+            /*
              * cover all the indices for which this route is the best
              * prefix match
              */
@@ -429,7 +429,7 @@ free_bucket(struct ip_bucket_entry *ent, int level, struct vr_route_req *rt)
     ent->entry_label_flags = rt->rtr_req.rtr_label_flags;
     ent->entry_label = rt->rtr_req.rtr_label;
     ent->entry_bridge_index = rt->rtr_req.rtr_index;
-    
+
     ip_bucket_sched_for_free(bkt, level);
 }
 
@@ -473,7 +473,7 @@ __mtrie_delete(struct vr_route_req *rt, struct ip_bucket_entry *ent,
                 tmp_ent->entry_label = rt->rtr_req.rtr_label;
                 tmp_ent->entry_prefix_len = rt->rtr_req.rtr_replace_plen;
                 tmp_ent->entry_bridge_index = rt->rtr_req.rtr_index;
-            } else 
+            } else
                 __mtrie_delete(rt, tmp_ent, level + 1);
         }
     }
@@ -482,11 +482,11 @@ __mtrie_delete(struct vr_route_req *rt, struct ip_bucket_entry *ent,
     for (i = 1; i < ip_bkt_info[level].bi_size; i++) {
         if ((bkt->bkt_data[i].entry_long_i == bkt->bkt_data[0].entry_long_i) &&
                 (bkt->bkt_data[i].entry_label_flags ==
-                	bkt->bkt_data[0].entry_label_flags) &&
+                    bkt->bkt_data[0].entry_label_flags) &&
                 (bkt->bkt_data[i].entry_label ==
-                	bkt->bkt_data[0].entry_label) && 
-                (bkt->bkt_data[i].entry_prefix_len == 
-			bkt->bkt_data[0].entry_prefix_len)) {
+                    bkt->bkt_data[0].entry_label) &&
+                (bkt->bkt_data[i].entry_prefix_len ==
+                    bkt->bkt_data[0].entry_prefix_len)) {
             continue;
         } else
             return 0;
@@ -631,7 +631,7 @@ mtrie_walk(struct vr_message_dumper *dumper, unsigned int family)
     req = (vr_route_req *)dumper->dump_req;
     mtrie = vrfid_to_mtrie(req->rtr_vrf_id, family);
     if (!mtrie)
-        return -EINVAL; 
+        return -EINVAL;
 
     ent = &mtrie->root;
 
@@ -747,9 +747,9 @@ mtrie_stats_get(vr_vrf_stats_req *req, vr_vrf_stats_req *response)
             response->vsr_evpn_composites += stats->vrf_evpn_composites;
             response->vsr_l2_mcast_composites += stats->vrf_l2_mcast_composites;
             response->vsr_fabric_composites += stats->vrf_fabric_composites;
-            response->vsr_udp_tunnels  += stats->vrf_udp_tunnels;
-            response->vsr_udp_mpls_tunnels  += stats->vrf_udp_mpls_tunnels;
-            response->vsr_gre_mpls_tunnels  += stats->vrf_gre_mpls_tunnels;
+            response->vsr_udp_tunnels += stats->vrf_udp_tunnels;
+            response->vsr_udp_mpls_tunnels += stats->vrf_udp_mpls_tunnels;
+            response->vsr_gre_mpls_tunnels += stats->vrf_gre_mpls_tunnels;
             response->vsr_l2_encaps += stats->vrf_l2_encaps;
             response->vsr_encaps += stats->vrf_encaps;
             response->vsr_gros += stats->vrf_gros;

--- a/dp-core/vr_mirror.c
+++ b/dp-core/vr_mirror.c
@@ -37,7 +37,7 @@ vrouter_get_mirror(unsigned int rid, unsigned int index)
 }
 
 int
-vrouter_put_mirror(struct vrouter *router, unsigned int index) 
+vrouter_put_mirror(struct vrouter *router, unsigned int index)
 {
     struct vr_mirror_entry *mirror;
 
@@ -137,7 +137,7 @@ vr_mirror_add(vr_mirror_req *req)
     req->mirr_flags &= ~VR_MIRROR_FLAG_MARKED_DELETE;
 
     nh = vrouter_get_nexthop(req->mirr_rid, req->mirr_nhid);
-    if (!nh)  {
+    if (!nh) {
         ret = -EINVAL;
         goto generate_resp;
     }
@@ -264,7 +264,7 @@ vr_mirror_req_process(void *s_req)
     default:
         break;
     }
- 
+
     return;
 }
 
@@ -320,7 +320,7 @@ vr_mirror_meta_entry_destroy(unsigned int index, void *arg)
 
 int
 vr_mirror_meta_entry_set(struct vrouter *router, unsigned int index,
-                         unsigned int mir_sip, unsigned short mir_sport, 
+                         unsigned int mir_sip, unsigned short mir_sport,
                          void *meta_data, unsigned int meta_data_len,
                          unsigned short mirror_vrf)
 {
@@ -348,7 +348,7 @@ vr_mirror_meta_entry_set(struct vrouter *router, unsigned int index,
     me_old = vr_itable_set(router->vr_mirror_md, index, me);
     if (me_old && me_old != VR_ITABLE_ERR_PTR)
         vr_mirror_meta_entry_destroy(index, (void *)me_old);
-    
+
     return 0;
 }
 
@@ -365,7 +365,7 @@ vr_mirror_meta_entry_del(struct vrouter *router, unsigned int index)
 }
 
 int
-vr_mirror(struct vrouter *router, uint8_t mirror_id, 
+vr_mirror(struct vrouter *router, uint8_t mirror_id,
           struct vr_packet *pkt, struct vr_forwarding_md *fmd)
 {
     unsigned char *buf;
@@ -413,11 +413,11 @@ vr_mirror(struct vrouter *router, uint8_t mirror_id,
             pkt_nh->nh_dev->vif_set_rewrite && pkt_nh->nh_encap_len) {
 
             reset = false;
-            if (vr_pcow(pkt,  VR_MIRROR_PKT_HEAD_SPACE + mirror_md_len +
-                    pkt_nh->nh_encap_len)) 
+            if (vr_pcow(pkt, VR_MIRROR_PKT_HEAD_SPACE + mirror_md_len +
+                    pkt_nh->nh_encap_len))
                 goto fail;
 
-            if (!pkt_nh->nh_dev->vif_set_rewrite(pkt_nh->nh_dev, pkt, 
+            if (!pkt_nh->nh_dev->vif_set_rewrite(pkt_nh->nh_dev, pkt,
                     pkt_nh->nh_data, pkt_nh->nh_encap_len))
                 goto fail;
         }
@@ -425,7 +425,7 @@ vr_mirror(struct vrouter *router, uint8_t mirror_id,
 
     if (reset) {
         vr_preset(pkt);
-        if (vr_pcow(pkt,  VR_MIRROR_PKT_HEAD_SPACE + mirror_md_len))
+        if (vr_pcow(pkt, VR_MIRROR_PKT_HEAD_SPACE + mirror_md_len))
             goto fail;
     }
 
@@ -439,7 +439,7 @@ vr_mirror(struct vrouter *router, uint8_t mirror_id,
         goto fail;
 
     captured_len = htonl(pkt_len(pkt));
-    if (mirror_md_len) 
+    if (mirror_md_len)
         memcpy(buf, mirror_md, mirror_md_len);
 
     if (mirror->mir_flags & VR_MIRROR_PCAP) {
@@ -447,10 +447,10 @@ vr_mirror(struct vrouter *router, uint8_t mirror_id,
         pcap = (struct vr_pcap *)pkt_push(pkt, sizeof(struct vr_pcap));
         if (!pcap)
             goto fail;
-        
+
         pcap->pcap_incl_len = captured_len;
         pcap->pcap_orig_len = captured_len;
-        
+
         /* Get the time stamp in seconds and nanoseconds*/
         vr_get_time(&pcap->pcap_ts_sec, &pcap->pcap_ts_usec);
         pcap->pcap_ts_sec = htonl(pcap->pcap_ts_sec);
@@ -474,7 +474,7 @@ vr_mirror_exit(struct vrouter *router, bool soft_reset)
 {
     unsigned int i;
 
-    if (router->vr_mirrors) 
+    if (router->vr_mirrors)
         for (i = 0; i < router->vr_max_mirror_indices; i++)
             if (router->vr_mirrors[i])
                 vrouter_put_mirror(router, i);
@@ -487,7 +487,7 @@ vr_mirror_exit(struct vrouter *router, bool soft_reset)
 
     if (!soft_reset) {
         vr_free(router->vr_mirrors);
-        router->vr_mirrors = NULL; 
+        router->vr_mirrors = NULL;
         router->vr_max_mirror_indices = 0;
     }
 

--- a/dp-core/vr_mpls.c
+++ b/dp-core/vr_mpls.c
@@ -34,6 +34,7 @@ int
 vr_mpls_del(vr_mpls_req *req)
 {
     struct vrouter *router;
+    struct vr_nexthop *nh;
     int ret = 0;
 
     router = vrouter_get(req->mr_rid);
@@ -47,8 +48,15 @@ vr_mpls_del(vr_mpls_req *req)
         goto generate_resp;
     }
 
-    if (router->vr_ilm[req->mr_label])
-        vrouter_put_nexthop(router->vr_ilm[req->mr_label]);
+    /* hardware packet filtering (Flow Director) support */
+    nh = router->vr_ilm[req->mr_label];
+    if (nh) {
+        if (vrouter_host->hos_del_mpls
+            && nh->nh_type == NH_ENCAP && !(nh->nh_flags & NH_FLAG_MCAST))
+            vrouter_host->hos_del_mpls(router, req->mr_label);
+
+        vrouter_put_nexthop(nh);
+    }
 
     router->vr_ilm[req->mr_label] = NULL;
 
@@ -77,12 +85,17 @@ vr_mpls_add(vr_mpls_req *req)
     }
 
     nh = vrouter_get_nexthop(req->mr_rid, req->mr_nhid);
-    if (!nh)  {
+    if (!nh) {
         ret = -EINVAL;
         goto generate_resp;
     }
 
     router->vr_ilm[req->mr_label] = nh;
+
+    /* hardware packet filtering (Flow Director) support */
+    if (vrouter_host->hos_add_mpls
+        && nh->nh_type == NH_ENCAP && !(nh->nh_flags & NH_FLAG_MCAST))
+        vrouter_host->hos_add_mpls(router, req->mr_label);
 
 generate_resp:
     vr_send_response(ret);

--- a/dp-core/vr_nexthop.c
+++ b/dp-core/vr_nexthop.c
@@ -40,7 +40,7 @@ __vrouter_get_nexthop(struct vrouter *router, unsigned int index)
 }
 
 struct vr_nexthop *
-vrouter_get_nexthop(unsigned int rid, unsigned int index) 
+vrouter_get_nexthop(unsigned int rid, unsigned int index)
 {
     struct vr_nexthop *nh;
     struct vrouter *router;
@@ -98,10 +98,10 @@ vrouter_add_nexthop(struct vr_nexthop *nh)
      * NH change just copies the field
      * over to nexthop, incase of change
      * just return
-     */  
+     */
     if (router->vr_nexthops[nh->nh_id])
         return 0;
- 
+
     nh->nh_users++;
     router->vr_nexthops[nh->nh_id] = nh;
     return 0;
@@ -111,9 +111,9 @@ static void
 nh_del(struct vr_nexthop *nh)
 {
     struct vrouter *router = vrouter_get(nh->nh_rid);
-    
+
     if (!router || nh->nh_id > router->vr_max_nexthops)
-        return; 
+        return;
 
     if (router->vr_nexthops[nh->nh_id]) {
         router->vr_nexthops[nh->nh_id] = NULL;
@@ -253,7 +253,7 @@ nh_push_mpls_header(struct vr_packet *pkt, unsigned int label)
     if (!lbl)
         return -ENOSPC;
 
-    /* Use the ttl from packet. If not ttl, 
+    /* Use the ttl from packet. If not ttl,
      * initialise to some arbitrary value */
     ttl = pkt->vp_ttl;
     if (!ttl) {
@@ -271,8 +271,8 @@ nh_push_mpls_header(struct vr_packet *pkt, unsigned int label)
  */
 static bool
 nh_udp_tunnel_helper(struct vr_packet *pkt, unsigned short sport,
-                     unsigned short dport, unsigned int sip, 
-                     unsigned int dip) 
+                     unsigned short dport, unsigned int sip,
+                     unsigned int dip)
 {
     struct vr_ip *ip;
     struct vr_udp *udp;
@@ -311,16 +311,16 @@ nh_udp_tunnel_helper(struct vr_packet *pkt, unsigned short sport,
     ip->ip_daddr = dip;
     ip->ip_len = htons(pkt_len(pkt));
 
-    /* 
-     * header checksum 
+    /*
+     * header checksum
      */
     ip->ip_csum = 0;
-    ip->ip_csum = vr_ip_csum(ip);    
+    ip->ip_csum = vr_ip_csum(ip);
 
     return true;
 }
 
-static bool 
+static bool
 nh_vxlan_tunnel_helper(struct vr_packet *pkt, struct vr_forwarding_md *fmd,
                        unsigned int sip, unsigned int dip)
 {
@@ -344,7 +344,7 @@ nh_vxlan_tunnel_helper(struct vr_packet *pkt, struct vr_forwarding_md *fmd,
      * the standard port is used till flow processing is done
      */
     if ((!fmd->fmd_udp_src_port) && (pkt->vp_type != VP_TYPE_IP6) &&
-            vr_get_udp_src_port)  {
+            vr_get_udp_src_port) {
         udp_src_port = vr_get_udp_src_port(pkt, fmd, fmd->fmd_dvrf);
         if (udp_src_port == 0) {
          return false;
@@ -356,7 +356,7 @@ nh_vxlan_tunnel_helper(struct vr_packet *pkt, struct vr_forwarding_md *fmd,
     vxlanh->vxlan_vnid = htonl(fmd->fmd_label << VR_VXLAN_VNID_SHIFT);
     vxlanh->vxlan_flags = htonl(VR_VXLAN_IBIT);
 
-    return nh_udp_tunnel_helper(pkt, htons(udp_src_port), 
+    return nh_udp_tunnel_helper(pkt, htons(udp_src_port),
                              htons(VR_VXLAN_UDP_DST_PORT), sip, dip);
 }
 
@@ -412,7 +412,7 @@ nh_composite_ecmp_validate_src(struct vr_packet *pkt, struct vr_nexthop *nh,
 
             cnh = nh->nh_component_nh[i].cnh;
             /* If direct nexthop is not valid, dont process it */
-            if (!cnh || !(cnh->nh_flags & NH_FLAG_VALID) || 
+            if (!cnh || !(cnh->nh_flags & NH_FLAG_VALID) ||
                                             !cnh->nh_validate_src)
                 continue;
 
@@ -576,7 +576,6 @@ nh_composite_mcast_validate_src(struct vr_packet *pkt, struct vr_nexthop *nh,
 }
 
 
-
 static int
 nh_composite_mcast_l2(struct vr_packet *pkt, struct vr_nexthop *nh,
                      struct vr_forwarding_md *fmd)
@@ -724,7 +723,7 @@ nh_composite_mcast_l2(struct vr_packet *pkt, struct vr_nexthop *nh,
         pkt_push(pkt, pull_len);
     }
 
-    /* 
+    /*
      * The packet can come to this nexthp either from Fabric or from VM.
      * Incase of Fabric, the packet would contain the Vxlan header and
      * control information. From VM, it contains neither of them
@@ -1119,7 +1118,7 @@ nh_composite_fabric(struct vr_packet *pkt, struct vr_nexthop *nh,
                 break;
             }
 
-            /* 
+            /*
              * Add vxlan encapsulation. The vxlan id need to be taken
              * from Bridge entry
              */
@@ -1176,11 +1175,11 @@ nh_udp_tunnel(struct vr_packet *pkt, struct vr_nexthop *nh,
 
     if (pkt_head_space(pkt) < VR_UDP_HEAD_SPACE) {
         tmp = vr_palloc_head(pkt, VR_UDP_HEAD_SPACE);
-        if (!tmp) 
+        if (!tmp)
             goto send_fail;
 
         pkt = tmp;
-        if (!pkt_reserve_head_space(pkt, VR_UDP_HEAD_SPACE)) 
+        if (!pkt_reserve_head_space(pkt, VR_UDP_HEAD_SPACE))
             goto send_fail;
     }
 
@@ -1193,8 +1192,8 @@ nh_udp_tunnel(struct vr_packet *pkt, struct vr_nexthop *nh,
 
     if (pkt_len(pkt) > ((1 << sizeof(ip->ip_len) * 8)))
         goto send_fail;
-    /* 
-     * Incase of mirroring set the inner network header to the newly added 
+    /*
+     * Incase of mirroring set the inner network header to the newly added
      * header so that this is fragmented and checksummed
      */
     pkt_set_inner_network_header(pkt, pkt->vp_data);
@@ -1291,7 +1290,7 @@ nh_vxlan_tunnel(struct vr_packet *pkt, struct vr_nexthop *nh,
 
     /* slap l2 header */
     vif = nh->nh_dev;
-    if (!vif->vif_set_rewrite(vif, pkt, nh->nh_data, 
+    if (!vif->vif_set_rewrite(vif, pkt, nh->nh_data,
                                      nh->nh_udp_tun_encap_len)) {
         goto send_fail;
     }
@@ -1346,7 +1345,7 @@ nh_mpls_udp_tunnel(struct vr_packet *pkt, struct vr_nexthop *nh,
         tun_sip = nh->nh_udp_tun_sip;
         tun_dip = nh->nh_udp_tun_dip;
         tun_encap_len = nh->nh_udp_tun_encap_len;
-    }    
+    }
 
     stats = vr_inet_vrf_stats(fmd->fmd_dvrf, pkt->vp_cpu);
     if (stats)
@@ -1394,7 +1393,7 @@ nh_mpls_udp_tunnel(struct vr_packet *pkt, struct vr_nexthop *nh,
 
     if (pkt_head_space(pkt) < mudp_head_space) {
         tmp_pkt = vr_pexpand_head(pkt, mudp_head_space - pkt_head_space(pkt));
-        if (!tmp_pkt) 
+        if (!tmp_pkt)
             goto send_fail;
 
         pkt = tmp_pkt;
@@ -1405,8 +1404,8 @@ nh_mpls_udp_tunnel(struct vr_packet *pkt, struct vr_nexthop *nh,
 
     if (vr_perfs)
         pkt->vp_flags |= VP_FLAG_GSO;
-   
-   
+
+
     /*
      * Change the packet type
      */
@@ -1417,7 +1416,7 @@ nh_mpls_udp_tunnel(struct vr_packet *pkt, struct vr_nexthop *nh,
     else
         pkt->vp_type = VP_TYPE_IP;
 
-    if (nh_udp_tunnel_helper(pkt, htons(udp_src_port), 
+    if (nh_udp_tunnel_helper(pkt, htons(udp_src_port),
                              htons(VR_MPLS_OVER_UDP_DST_PORT),
                              tun_sip, tun_dip) == false) {
         goto send_fail;
@@ -1427,7 +1426,7 @@ nh_mpls_udp_tunnel(struct vr_packet *pkt, struct vr_nexthop *nh,
 
     /* slap l2 header */
     vif = nh->nh_dev;
-    tun_encap = vif->vif_set_rewrite(vif, pkt, nh->nh_data, 
+    tun_encap = vif->vif_set_rewrite(vif, pkt, nh->nh_data,
                                      tun_encap_len);
     if (!tun_encap) {
         goto send_fail;
@@ -1487,7 +1486,7 @@ nh_gre_tunnel(struct vr_packet *pkt, struct vr_nexthop *nh,
      * when ECMP source initiates traffic to a target in a remote (not in
      * the same) server. vr_forward->tunnel_nh->nh_output sets pkt->vp_nh
      * (source is ECMP)->pass through flow lookup->
-     */ 
+     */
     if (!fmd || fmd->fmd_label < 0)
         return vr_forward(nh->nh_router, pkt, fmd);
 
@@ -1810,12 +1809,12 @@ nh_l2_rcv_add(struct vr_nexthop *nh, vr_nexthop_req *req)
 static int
 nh_rcv_add(struct vr_nexthop *nh, vr_nexthop_req *req)
 {
-    struct vr_interface  *vif, *old_vif;
+    struct vr_interface *vif, *old_vif;
     vif = vrouter_get_interface(nh->nh_rid, req->nhr_encap_oif_id);
     if (!vif)
         return -ENODEV;
-    /* 
-     *  We need to delete the reference to old_vif only after new vif is
+    /*
+     * We need to delete the reference to old_vif only after new vif is
      * added to NH
      */
     old_vif = nh->nh_dev;
@@ -1940,12 +1939,12 @@ nh_composite_add(struct vr_nexthop *nh, vr_nexthop_req *req)
         return 0;
 
     nh->nh_component_nh = vr_zalloc(req->nhr_nh_list_size *
-            sizeof(struct vr_component_nh)); 
+            sizeof(struct vr_component_nh));
     if (!nh->nh_component_nh) {
         return -ENOMEM;
     }
     for (i = 0; i < req->nhr_nh_list_size; i++) {
-        nh->nh_component_nh[i].cnh = vrouter_get_nexthop(req->nhr_rid, 
+        nh->nh_component_nh[i].cnh = vrouter_get_nexthop(req->nhr_rid,
                                                     req->nhr_nh_list[i]);
         nh->nh_component_nh[i].cnh_label = req->nhr_label_list[i];
     }
@@ -2054,11 +2053,11 @@ nh_encap_add(struct vr_nexthop *nh, vr_nexthop_req *req)
     struct vr_interface *vif, *old_vif;;
 
     vif = vrouter_get_interface(nh->nh_rid, req->nhr_encap_oif_id);
-    if (!vif) 
+    if (!vif)
         return -ENODEV;
 
-    /* 
-     *  We need to delete the reference to old_vif only after new vif is
+    /*
+     * We need to delete the reference to old_vif only after new vif is
      * added to NH
      */
     old_vif = nh->nh_dev;
@@ -2168,7 +2167,7 @@ vr_nexthop_add(vr_nexthop_req *req)
 
         nh->nh_data_size = len - sizeof(struct vr_nexthop);
     } else {
-        /* 
+        /*
          * If modification of old_nh change the action to discard and ensure
          * everybody sees that
          */
@@ -2178,12 +2177,12 @@ vr_nexthop_add(vr_nexthop_req *req)
         }
 
         /* Lets track if invalid to valid change */
-        if ((req->nhr_flags & NH_FLAG_VALID) && 
+        if ((req->nhr_flags & NH_FLAG_VALID) &&
                 !(nh->nh_flags & NH_FLAG_VALID))
             invalid_to_valid = true;
 
         /* If valid to invalid lets propogate flags immediagtely */
-        if (!(req->nhr_flags & NH_FLAG_VALID) && 
+        if (!(req->nhr_flags & NH_FLAG_VALID) &&
                 (nh->nh_flags & NH_FLAG_VALID))
             nh->nh_flags = req->nhr_flags;
 
@@ -2201,7 +2200,7 @@ vr_nexthop_add(vr_nexthop_req *req)
     nh->nh_router = vrouter_get(nh->nh_rid);
     nh->nh_vrf = req->nhr_vrf;
 
-    /* 
+    /*
      * If invalid to valid, lets make it valid after the whole nexthop
      * is cookedup. For invalid to invalid, valid to valid, lets
      * copy the flags as is
@@ -2437,7 +2436,7 @@ vr_nexthop_get(vr_nexthop_req *req)
     if (!router || (unsigned int)req->nhr_id >= router->vr_max_nexthops) {
         ret = -ENODEV;
         goto generate_response;
-    } 
+    }
 
     nh = __vrouter_get_nexthop(router, req->nhr_id);
     if (nh) {
@@ -2489,7 +2488,7 @@ vr_nexthop_dump(vr_nexthop_req *r)
            if (ret || ((ret = vr_message_dump_object(dumper,
                            VR_NEXTHOP_OBJECT_ID, resp)) <= 0)) {
                vr_nexthop_req_destroy(resp);
-               if (ret <= 0) 
+               if (ret <= 0)
                    break;
            }
 

--- a/dp-core/vr_proto_ip.c
+++ b/dp-core/vr_proto_ip.c
@@ -264,8 +264,8 @@ vr_forward(struct vrouter *router, struct vr_packet *pkt,
             fmd = &rt_fmd;
         }
         fmd->fmd_label = rt.rtr_req.rtr_label;
-    } 
-    
+    }
+
     vif = nh->nh_dev;
 
     if (vif) {
@@ -414,7 +414,7 @@ vr_udp_input(struct vrouter *router, struct vr_packet *pkt,
         /* Fall through to the slower path */
         ASSERT(ret == PKT_RET_SLOW_PATH);
     }
-   
+
     udph = (struct vr_udp *)vr_pheader_pointer(pkt, sizeof(struct vr_udp),
                                                 &udp);
     if (udph == NULL) {
@@ -553,7 +553,7 @@ vr_ip_rcv(struct vrouter *router, struct vr_packet *pkt,
      * me or not. there are two ways a packet can reach here. either through
      *
      * route lookup->receive nexthop->vr_ip_rcv or through
-     * VP_FLAG_TO_ME(NO route lookup(!vp->vp_nh))->vr_ip_rcv 
+     * VP_FLAG_TO_ME(NO route lookup(!vp->vp_nh))->vr_ip_rcv
      */
     if ((pkt->vp_nh) || (vr_myip(pkt->vp_if, ip->ip_daddr))) {
         if (ip->ip_proto == VR_IP_PROTO_GRE) {

--- a/dp-core/vr_response.c
+++ b/dp-core/vr_response.c
@@ -11,7 +11,7 @@
 int vr_generate_response(vr_response *, int code, unsigned char *, int);
 
 void
-vr_response_process(void *s_req) 
+vr_response_process(void *s_req)
 {
 }
 

--- a/dp-core/vr_route.c
+++ b/dp-core/vr_route.c
@@ -120,7 +120,7 @@ vr_route_get(vr_route_req *req)
     int ret = 0;
     uint32_t rt_prefix[4];
 	struct vr_rtable *rtable;
-   
+
     vr_req.rtr_req = *req;
 
     vr_req.rtr_req.rtr_marker_size = 0;
@@ -159,7 +159,7 @@ vr_route_dump(vr_route_req *req)
     struct vr_rtable *rtable = NULL;
     int ret;
     uint32_t rt_prefix[4], rt_marker[4];
-   
+
     vr_req.rtr_req = *req;
     vr_req.rtr_req.rtr_prefix_size = req->rtr_prefix_size;
     if (req->rtr_prefix_size) {
@@ -251,7 +251,7 @@ vr_inet_vrf_stats_dump(struct vrouter *router, vr_vrf_stats_req *req)
 
 generate_error:
     vr_send_response(ret);
-    return; 
+    return;
 }
 
 static void
@@ -267,7 +267,7 @@ vr_inet_vrf_stats_get(struct vrouter *router, vr_vrf_stats_req *req)
         goto generate_error;
     }
 
-    if (req->vsr_vrf >= 0 && 
+    if (req->vsr_vrf >= 0 &&
             (unsigned int)req->vsr_vrf >= rtable->algo_max_vrfs) {
         ret = -EINVAL;
         goto generate_error;
@@ -312,7 +312,7 @@ vr_vrf_stats_op(vr_vrf_stats_req *req)
         goto generate_error;
     }
 
-    return; 
+    return;
 
 generate_error:
     vr_send_response(ret);
@@ -417,7 +417,7 @@ inet_route_del(struct rtable_fspec *fs, struct vr_route_req *req)
 }
 
 static void
-inet_rtb_family_deinit(struct rtable_fspec *fs, struct vrouter *router, 
+inet_rtb_family_deinit(struct rtable_fspec *fs, struct vrouter *router,
                                                         bool soft_reset)
 {
 
@@ -426,7 +426,7 @@ inet_rtb_family_deinit(struct rtable_fspec *fs, struct vrouter *router,
         vr_free(router->vr_inet_rtable);
         router->vr_inet_rtable = NULL;
     }
-   
+
     return;
 }
 
@@ -493,7 +493,7 @@ bridge_rtb_family_init(struct rtable_fspec *fs, struct vrouter *router)
 {
     int ret;
     struct vr_rtable *table = NULL;
-    
+
     if (router->vr_bridge_rtable)
         return 0;
 
@@ -512,7 +512,7 @@ bridge_rtb_family_init(struct rtable_fspec *fs, struct vrouter *router)
 }
 
 static void
-bridge_rtb_family_deinit(struct rtable_fspec *fs, struct vrouter *router, 
+bridge_rtb_family_deinit(struct rtable_fspec *fs, struct vrouter *router,
                                                             bool soft_reset)
 {
 
@@ -576,7 +576,7 @@ vr_fib_exit(struct vrouter *router, bool soft_reset)
     return;
 }
 
-int 
+int
 vr_fib_init(struct vrouter *router)
 {
     int i;

--- a/dp-core/vr_stats.c
+++ b/dp-core/vr_stats.c
@@ -27,7 +27,7 @@ vr_drop_stats_fill_response(vr_drop_stats_req *response,
     response->vds_flow_queue_limit_exceeded =
         stats->vds_flow_queue_limit_exceeded;
     response->vds_flow_no_memory = stats->vds_flow_no_memory;
-    response->vds_flow_invalid_protocol = 
+    response->vds_flow_invalid_protocol =
         stats->vds_flow_invalid_protocol;
     response->vds_flow_nat_no_rflow = stats->vds_flow_nat_no_rflow;
     response->vds_flow_action_drop = stats->vds_flow_action_drop;
@@ -101,7 +101,7 @@ vr_drop_stats_get(void)
         stats->vds_invalid_arp += stats_block->vds_invalid_arp;
         stats->vds_trap_no_if += stats_block->vds_trap_no_if;
         stats->vds_nowhere_to_go += stats_block->vds_nowhere_to_go;
-        stats->vds_flow_queue_limit_exceeded += 
+        stats->vds_flow_queue_limit_exceeded +=
             stats_block->vds_flow_queue_limit_exceeded;
         stats->vds_flow_no_memory += stats_block->vds_flow_no_memory;
         stats->vds_flow_invalid_protocol +=
@@ -166,7 +166,7 @@ vr_drop_stats_req_process(void *s_req)
 
     if ((req->h_op != SANDESH_OP_GET) && (ret = -EOPNOTSUPP))
         vr_send_response(ret);
-    
+
     vr_drop_stats_get();
     return;
 }

--- a/dp-core/vr_vxlan.c
+++ b/dp-core/vr_vxlan.c
@@ -14,7 +14,7 @@
 #include "vr_datapath.h"
 
 int
-vr_vxlan_input(struct vrouter *router, struct vr_packet *pkt, 
+vr_vxlan_input(struct vrouter *router, struct vr_packet *pkt,
                                 struct vr_forwarding_md *fmd)
 {
     struct vr_vxlan *vxlan;
@@ -44,7 +44,7 @@ vr_vxlan_input(struct vrouter *router, struct vr_packet *pkt,
     }
     fmd->fmd_label = vnid;
 
-    nh = (struct vr_nexthop *)vr_itable_get(router->vr_vxlan_table, vnid); 
+    nh = (struct vr_nexthop *)vr_itable_get(router->vr_vxlan_table, vnid);
     if (!nh) {
         drop_reason = VP_DROP_INVALID_VNID;
         goto fail;
@@ -131,7 +131,7 @@ vr_vxlan_get(vr_vxlan_req *req)
     if (!router) {
         ret = -ENODEV;
     } else {
-        nh = (struct vr_nexthop *)vr_itable_get(router->vr_vxlan_table, req->vxlanr_vnid); 
+        nh = (struct vr_nexthop *)vr_itable_get(router->vr_vxlan_table, req->vxlanr_vnid);
         if (!nh)
             ret = -ENOENT;
     }
@@ -182,11 +182,11 @@ vr_vxlan_add(vr_vxlan_req *req)
     }
 
     nh = vrouter_get_nexthop(req->vxlanr_rid, req->vxlanr_nhid);
-    if (!nh)  {
+    if (!nh) {
         ret = -EINVAL;
         goto generate_resp;
     }
-    
+
     nh_old = vr_itable_set(router->vr_vxlan_table, req->vxlanr_vnid, nh);
     if (nh_old) {
         if (nh_old == VR_ITABLE_ERR_PTR) {

--- a/dpdk/SConscript
+++ b/dpdk/SConscript
@@ -1,0 +1,72 @@
+#
+# Copyright (c) 2014 Semihalf. All rights reserved.
+#
+import os
+
+Import('VRouterEnv')
+
+env = VRouterEnv.Clone()
+
+# Include paths
+
+# CFLAGS
+env.Append(CCFLAGS = '-Werror -Wall')
+env.Append(CCFLAGS = '-D__DPDK__')
+
+env.Replace(LIBPATH = env['TOP_LIB'])
+env.Append(LIBPATH = ['../host', '../sandesh', '../dp-core'])
+env.Append(LIBPATH = ['#third_party/dpdk/build/lib'])
+
+env.Replace(LIBS = ['dp_core', 'dp_sandesh_c', 'dp_core', 'sandesh-c'])
+
+# Add all dpdk libraries
+env.Append(LIBS = ['rte_kvargs', 'rte_pmd_ixgbe', 'rte_kni',
+    'rte_hash', 'rte_mempool', 'rte_ring', 'rte_mbuf', 'rte_eal', 'rte_malloc',
+    'rte_port', 'rte_timer', 'ethdev'])
+
+# Add libraries required by dpdk
+env.Append(LIBS = ['rt', 'dl', 'pthread'])
+env.Append(LIBS = ['urcu-qsbr'])
+
+env.Append(LINKCOM =
+    ' -Wl,--whole-archive -lrte_pmd_e1000 -lrte_pmd_ixgbe -Wl,--no-whole-archive')
+
+dpdk_dir ='#third_party/dpdk/'
+make_dir = Dir(dpdk_dir).srcnode().abspath
+
+make_cmd = 'make config T=x86_64-native-linuxapp-gcc; make'
+dpdk_lib = env.Command('dpdk_lib', None, make_cmd, chdir=make_dir)
+env.AlwaysBuild(dpdk_lib)
+env.Default(dpdk_lib)
+
+dpdk_vrouter_src = [ 'dpdk_vrouter.c',
+                     'vr_dpdk_ethdev.c',
+                     'vr_dpdk_flow_mem.c',
+                     'vr_dpdk_host.c',
+                     'vr_dpdk_interface.c',
+                     'vr_dpdk_knidev.c',
+                     'vr_dpdk_lcore.c',
+                     'vr_dpdk_netlink.c',
+                     'vr_dpdk_packet.c',
+                     'vr_dpdk_ringdev.c',
+                     'vr_dpdk_usocket.c',
+                     'vr_dpdk_virtio.c',
+                     'vr_uvhost.c',
+                     'vr_uvhost_util.c',
+                     'vr_uvhost_msg.c',
+                     'vr_uvhost_client.c'
+                   ]
+
+dpdk_vrouter = env.Program('contrail-vrouter-dpdk', dpdk_vrouter_src)
+env.Requires(dpdk_vrouter, dpdk_lib)
+
+if GetOption('clean'):
+    os.system('cd ' + make_dir + ';' + make_cmd + ' clean')
+# to make sure that all are built when you do 'scons' @ the top level
+env.Default(dpdk_vrouter)
+
+env.Alias('install', env.Install(env['INSTALL_BIN'], dpdk_vrouter))
+
+# Local Variables:
+# mode: python
+# End:

--- a/dpdk/dpdk_vrouter.c
+++ b/dpdk/dpdk_vrouter.c
@@ -1,0 +1,538 @@
+/*
+ * Copyright (C) 2014 Semihalf.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation version 2.
+ *
+ * This program is distributed "as is" WITHOUT ANY WARRANTY of any
+ * kind, whether express or implied; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * dpdk_vrouter.c -- vRouter/DPDK application
+ *
+ */
+#define _GNU_SOURCE
+#include <sched.h>
+
+#include <getopt.h>
+#include <signal.h>
+#include <linux/vhost.h>
+
+#include <rte_timer.h>
+#include <rte_errno.h>
+
+#include "vr_dpdk.h"
+#include "vr_uvhost.h"
+#include "qemu_uvhost.h"
+#include "vr_dpdk_virtio.h"
+
+static int no_daemon_set;
+extern char *ContrailBuildInfo;
+
+/* Global vRouter/DPDK structure */
+struct vr_dpdk_global vr_dpdk;
+
+/* TODO: default commandline params */
+static char *dpdk_argv[] = {
+    "dpdk",
+    "-m", VR_DPDK_MAX_MEM,
+    "-c", "",
+    "-n", VR_DPDK_MAX_MEMCHANNELS
+};
+static int dpdk_argc = sizeof(dpdk_argv)/sizeof(*dpdk_argv);
+
+/* Pktmbuf constructor with vr_packet support */
+void
+vr_dpdk_pktmbuf_init(struct rte_mempool *mp, void *opaque_arg, void *_m, unsigned i)
+{
+    struct rte_mbuf *m = _m;
+    struct vr_packet *pkt;
+    rte_pktmbuf_init(mp, opaque_arg, _m, i);
+
+    /* decrease rte packet size to fit vr_packet struct */
+    m->buf_len -= sizeof(struct vr_packet);
+    RTE_VERIFY(0 < m->buf_len);
+
+    /* basic vr_packet initialization */
+    pkt = vr_dpdk_mbuf_to_pkt(m);
+    pkt->vp_head = (unsigned char *)m->buf_addr;
+    pkt->vp_end = m->buf_len;
+}
+
+/* Create memory pools */
+static int
+dpdk_mempools_create(void)
+{
+    /* Create the mbuf pool used for receiving from VM virtio interfaces */
+    vr_dpdk.virtio_mempool = rte_mempool_create("virtio_mempool",
+                                 VR_DPDK_VIRTIO_MEMPOOL_SZ,
+                                 VR_DPDK_MBUF_SZ,
+                                 VR_DPDK_VIRTIO_MEMPOOL_CACHE_SZ,
+                                 sizeof(struct rte_pktmbuf_pool_private),
+                                 rte_pktmbuf_pool_init, NULL,
+                                 vr_dpdk_pktmbuf_init, NULL,
+                                 rte_socket_id(), 0);
+    if (vr_dpdk.virtio_mempool == NULL) {
+        RTE_LOG(CRIT, VROUTER, "Error creating virtio mempool: %s (%d)\n",
+            rte_strerror(rte_errno), rte_errno);
+        return -rte_errno;
+    }
+
+    /* Create the mbuf pool used for RSS */
+    vr_dpdk.rss_mempool = rte_mempool_create("rss_mempool", VR_DPDK_RSS_MEMPOOL_SZ,
+            VR_DPDK_MBUF_SZ, VR_DPDK_RSS_MEMPOOL_CACHE_SZ,
+            sizeof(struct rte_pktmbuf_pool_private),
+            rte_pktmbuf_pool_init, NULL, vr_dpdk_pktmbuf_init, NULL,
+            rte_socket_id(), 0);
+    if (vr_dpdk.rss_mempool == NULL) {
+        RTE_LOG(CRIT, VROUTER, "Error creating RSS mempool: %s (%d)\n",
+            rte_strerror(rte_errno), rte_errno);
+        return -rte_errno;
+    }
+
+    int ret, i;
+    char mempool_name[RTE_MEMPOOL_NAMESIZE];
+
+    /* Create a list of free mempools */
+    vr_dpdk.nb_free_mempools = 0;
+    for (i = 0; i < VR_DPDK_MAX_VM_MEMPOOLS; i++) {
+        ret = snprintf(mempool_name, sizeof(mempool_name), "vr_mempool_%d", i);
+        if (ret >= sizeof(mempool_name)) {
+            RTE_LOG(INFO, VROUTER, "Error creating mempool %d name\n", i);
+            return -ENOMEM;
+        }
+        vr_dpdk.free_mempools[i] = rte_mempool_create(mempool_name,
+                VR_DPDK_VM_MEMPOOL_SZ, VR_DPDK_MBUF_SZ, VR_DPDK_VM_MEMPOOL_CACHE_SZ,
+                sizeof(struct rte_pktmbuf_pool_private),
+                rte_pktmbuf_pool_init, NULL, vr_dpdk_pktmbuf_init, NULL,
+                rte_socket_id(), 0);
+        if (vr_dpdk.free_mempools[i] == NULL) {
+            RTE_LOG(CRIT, VROUTER, "Error creating mempool %d: %s (%d)\n",
+                i, rte_strerror(rte_errno), rte_errno);
+            return -rte_errno;
+        }
+        vr_dpdk.nb_free_mempools++;
+    }
+    RTE_LOG(INFO, VROUTER, "Allocated %" PRIu16 " mempool(s)\n",
+        vr_dpdk.nb_free_mempools);
+
+    return 0;
+}
+
+/*
+ * Figure out a number of CPU cores/threads and compute an affinity mask
+ * which will be passed to EAL initialization in dpdk_init().
+ *
+ * Returns:
+ *      new core mask on success
+ *      VR_DPDK_LCORE_MASK on failure
+ */
+static uint64_t
+dpdk_core_mask_get(void) {
+    cpu_set_t cs;
+    uint64_t cpu_core_mask = 0;
+    int i;
+    unsigned int cpu_core_mask_ones, vr_dpdk_lcore_mask_ones;
+
+    /*
+     * If it is impossible to get the cpu_set_t structure, return
+     * VR_DPDK_LCORE_MASK as a default value.
+     */
+    if (sched_getaffinity(0, sizeof(cs), &cs) < 0)
+        return VR_DPDK_LCORE_MASK;
+
+    /*
+     * Go through all the CPUs in the cpu_set_t structure to check
+     * if they are available or not. Build an affinity mask based on that.
+     * There is no official way to obtain the mask directly, as there is
+     * no macro for this.
+     *
+     * Due to size of uint64_t, maximum number of supported CPUs is 64.
+     */
+    for (i = 0; i < RTE_MIN(CPU_SETSIZE, 64); i++) {
+        if (CPU_ISSET(i, &cs))
+            cpu_core_mask |= (uint64_t)1 << i;
+    }
+
+    if(!cpu_core_mask)
+        return VR_DPDK_LCORE_MASK;
+
+    /*
+     * After successfully building the affinity mask, we should return one of
+     * the following:
+     *
+     * return cpu_core_mask, if:
+     *      * we have as many CPUs (bits set) as in VR_DPDK_LCORE_MASK.
+     *      CPUs may have different affinity than set in the default mask
+     *      and we want to prioritize that setting.
+     *
+     *      * we have less CPUs than defined in VR_DPDK_LCORE_MASK.
+     *
+     * return (cpu_core_mask & VR_DPDK_LCORE_MASK), if:
+     *      * we have more CPUs (bits set) than defined in VR_DPDK_LCORE_MASK.
+     *      This will left some CPUs available for other tasks, eg. VMs.
+     */
+    cpu_core_mask_ones
+                = __builtin_popcountll((unsigned long long)cpu_core_mask);
+    vr_dpdk_lcore_mask_ones
+                = __builtin_popcountll((unsigned long long)VR_DPDK_LCORE_MASK);
+
+    if(cpu_core_mask_ones > vr_dpdk_lcore_mask_ones)
+        return (cpu_core_mask & VR_DPDK_LCORE_MASK);
+    else
+        return cpu_core_mask;
+}
+
+/* Updates parameters of EAL initialization in dpdk_argv[]. */
+static void
+dpdk_argv_update(void) {
+    static char core_mask_string[19];
+
+    snprintf(core_mask_string, sizeof(core_mask_string), "0x%" PRIx64,
+                dpdk_core_mask_get());
+    dpdk_argv[4] = core_mask_string;
+}
+
+/* Init DPDK EAL */
+static int
+dpdk_init(void)
+{
+    int ret, nb_sys_ports;
+
+    ret = vr_dpdk_flow_mem_init();
+    if (ret < 0) {
+        fprintf(stderr, "Error initializing flow table: %s (%d)\n",
+            rte_strerror(-ret), -ret);
+        return ret;
+    }
+
+    dpdk_argv_update();
+
+    ret = rte_eal_init(dpdk_argc, dpdk_argv);
+    if (ret < 0) {
+        fprintf(stderr, "Error initializing EAL\n");
+        return ret;
+    }
+
+    /* TODO: for DPDK 1.8+ */
+    /* rte_kni_init(max_kni_ifaces); */
+
+    ret = dpdk_mempools_create();
+    if (ret < 0)
+        return ret;
+
+    /* Scan PCI bus for recognised devices */
+    ret = rte_eal_pci_probe();
+    if (ret < 0) {
+        RTE_LOG(CRIT, VROUTER, "Error probing PCI: %s (%d)\n", rte_strerror(-ret), -ret);
+        return ret;
+    }
+
+    /* Get number of ports found in scan */
+    nb_sys_ports = rte_eth_dev_count();
+    RTE_LOG(INFO, VROUTER, "Found %d eth device(s)\n", nb_sys_ports);
+
+    /* Enable all detected lcores */
+    vr_dpdk.nb_fwd_lcores = rte_lcore_count();
+    if (vr_dpdk.nb_fwd_lcores >= VR_DPDK_MIN_LCORES) {
+        /* do not use service lcores */
+        vr_dpdk.nb_fwd_lcores -= VR_DPDK_NB_SERVICE_LCORES;
+        if (vr_dpdk.nb_fwd_lcores == 0)
+            vr_dpdk.nb_fwd_lcores = 1;
+        RTE_LOG(INFO, VROUTER, "Using %i forwarding lcore(s)\n", vr_dpdk.nb_fwd_lcores);
+        RTE_LOG(INFO, VROUTER, "Using %i service lcore(s)\n",
+            rte_lcore_count() - vr_dpdk.nb_fwd_lcores);
+    } else {
+        RTE_LOG(CRIT, VROUTER, "Please enable at least 2 lcores\n");
+        return -ENODEV;
+    }
+
+    /* init timer subsystem */
+    rte_timer_subsystem_init();
+
+    /* Init the interface configuration mutex
+     * ATM we use it just to synchronize access between the NetLink interface
+     * and kernel KNI events. The datapath is not affected. */
+    return pthread_mutex_init(&vr_dpdk.if_lock, NULL);
+}
+
+/* Shutdown DPDK EAL */
+static void
+dpdk_exit(void)
+{
+    int i;
+
+    vr_dpdk_if_lock();
+    RTE_LOG(INFO, VROUTER, "Releasing KNI devices...\n");
+    for (i = 0; i < VR_MAX_INTERFACES; i++) {
+        if (vr_dpdk.knis[i] != NULL) {
+            rte_kni_release(vr_dpdk.knis[i]);
+            vr_dpdk.knis[i] = NULL;
+        }
+    }
+
+    RTE_LOG(INFO, VROUTER, "Closing eth devices...\n");
+    for (i = 0; i < RTE_MAX_ETHPORTS; i++) {
+        if (vr_dpdk.ethdevs[i].ethdev_ptr != NULL) {
+            rte_eth_dev_stop(i);
+            rte_eth_dev_close(i);
+            vr_dpdk.ethdevs[i].ethdev_ptr = NULL;
+        }
+    }
+    vr_dpdk_if_unlock();
+
+    /* destroy interface lock */
+    if (pthread_mutex_destroy(&vr_dpdk.if_lock)) {
+        RTE_LOG(ERR, VROUTER, "Error destroying interface lock\n");
+    }
+}
+
+/* Timer handling loop */
+static void *
+dpdk_timer_loop(__attribute__((unused)) void *dummy)
+{
+    while (1) {
+        rte_timer_manage();
+
+        /* check for the global stop flag */
+        if (unlikely(rte_atomic16_read(&vr_dpdk.stop_flag)))
+            break;
+
+        usleep(VR_DPDK_SLEEP_TIMER_US);
+    };
+    return NULL;
+}
+
+/* KNI handling loop */
+static void *
+dpdk_kni_loop(__attribute__((unused)) void *dummy)
+{
+    while (1) {
+        vr_dpdk_knidev_all_handle();
+
+        /* check for the global stop flag */
+        if (unlikely(rte_atomic16_read(&vr_dpdk.stop_flag)))
+            break;
+
+        usleep(VR_DPDK_SLEEP_KNI_US);
+    };
+    return NULL;
+}
+
+/* Set stop flag for all lcores */
+static void
+dpdk_stop_flag_set(void) {
+    unsigned lcore_id;
+    struct vr_dpdk_lcore *lcore;
+
+    /* check if the flag is already set */
+    if (unlikely(rte_atomic16_read(&vr_dpdk.stop_flag)))
+        return;
+
+    RTE_LCORE_FOREACH(lcore_id) {
+        lcore = vr_dpdk.lcores[lcore_id];
+        vr_dpdk_lcore_cmd_post(lcore, VR_DPDK_LCORE_STOP_CMD, 0);
+    }
+
+    rte_atomic16_inc(&vr_dpdk.stop_flag);
+}
+
+/* Custom handling of signals */
+static void
+dpdk_signal_handler(int signum)
+{
+    RTE_LOG(DEBUG, VROUTER, "Got signal %i on lcore %u\n",
+            signum, rte_lcore_id());
+
+    dpdk_stop_flag_set();
+}
+
+/* Setup signal handlers */
+static int
+dpdk_signals_init(void)
+{
+    struct sigaction act;
+
+    memset(&act, 0 , sizeof(act));
+    act.sa_handler = dpdk_signal_handler;
+
+    if (sigaction(SIGTERM, &act, NULL) != 0) {
+        RTE_LOG(CRIT, VROUTER, "Fail to register SIGTERM handler\n");
+        return -1;
+    }
+
+    if (sigaction(SIGINT, &act, NULL) != 0) {
+        RTE_LOG(CRIT, VROUTER, "Fail to register SIGINT handler\n");
+        return -1;
+    }
+
+    /* ignore sigpipes emanating from sockets that are closed */
+    act.sa_handler = SIG_IGN;
+    if (sigaction(SIGPIPE, &act, NULL) != 0) {
+        RTE_LOG(CRIT, VROUTER, "Failed to ignore SIGPIPE\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+/* Cancel all threads */
+static void
+dpdk_threads_cancel(void)
+{
+    if (vr_dpdk.kni_thread)
+        pthread_cancel(vr_dpdk.kni_thread);
+    if (vr_dpdk.timer_thread)
+        pthread_cancel(vr_dpdk.timer_thread);
+}
+
+/* Wait for other threads to join */
+static void
+dpdk_threads_join(void)
+{
+    if (vr_dpdk.kni_thread)
+        pthread_join(vr_dpdk.kni_thread, NULL);
+    if (vr_dpdk.timer_thread)
+        pthread_join(vr_dpdk.timer_thread, NULL);
+}
+
+
+/* Create threads to handle KNI, timers, NetLink etc */
+static int
+dpdk_threads_create(void)
+{
+    int ret;
+
+    /* thread to handle KNI requests */
+    ret = pthread_create(&vr_dpdk.kni_thread, NULL,
+            &dpdk_kni_loop, NULL);
+    if (ret != 0) {
+        RTE_LOG(CRIT, VROUTER, "Error creating KNI thread: %s (%d)\n",
+            rte_strerror(ret), ret);
+        return ret;
+    }
+    /* thread to handle timers */
+    ret = pthread_create(&vr_dpdk.timer_thread, NULL,
+            &dpdk_timer_loop, NULL);
+    if (ret != 0) {
+        RTE_LOG(CRIT, VROUTER, "Error creating timer thread: %s (%d)\n",
+            rte_strerror(ret), ret);
+
+        return ret;
+    }
+
+    return 0;
+}
+
+enum vr_opt_index {
+    DAEMON_OPT_INDEX,
+    MAX_OPT_INDEX
+};
+
+static struct option long_options[] = {
+    [DAEMON_OPT_INDEX]              =   {"no-daemon",           no_argument,
+                                                    &no_daemon_set,         1},
+    [MAX_OPT_INDEX]                 =   {NULL,                  0,
+                                                    NULL,                   0},
+};
+
+/*
+ * vr_dpdk_exit_trigger - function that is called by user space vhost server
+ * to cause all DPDK threads to exit.
+ *
+ * Returns nothing.
+ */
+static void
+vr_dpdk_exit_trigger(void)
+{
+    dpdk_stop_flag_set();
+
+    return;
+}
+
+int
+main(int argc, char *argv[])
+{
+    int ret, opt, option_index;
+
+    fprintf(stdout, "vRouter/DPDK version: %s\n", ContrailBuildInfo);
+    fflush(stdout);
+
+    while ((opt = getopt_long(argc, argv, "", long_options, &option_index))
+            >= 0) {
+        switch (opt) {
+        case 0:
+            break;
+
+        case '?':
+        default:
+            fprintf(stderr, "Invalid option %s\n", argv[optind - 1]);
+            exit(-EINVAL);
+            break;
+        }
+    }
+    /* for other getopts in dpdk */
+    optind = 0;
+
+    if (!no_daemon_set) {
+        if (daemon(0, 0) < 0)
+            return -1;
+    }
+
+    /* Create user space vhost thread */
+    if ((ret = vr_uvhost_init(&vr_dpdk.uvh_thread, vr_dpdk_exit_trigger))) {
+        return ret;
+    }
+
+    /* init DPDK first since vRouter uses DPDK mallocs and logs */
+    ret = dpdk_init();
+    if (ret != 0) {
+        return ret;
+    }
+
+    /* associate signal hanlder with signals */
+    ret = dpdk_signals_init();
+    if (ret != 0) {
+        dpdk_exit();
+        return ret;
+    }
+
+    /* init the vRouter */
+    ret = vr_dpdk_host_init();
+    if (ret != 0) {
+        dpdk_exit();
+        return ret;
+    }
+
+    /* init the communication socket with agent */
+    ret = dpdk_netlink_init();
+    if (ret != 0) {
+        vr_dpdk_host_exit();
+        dpdk_exit();
+        return ret;
+    }
+
+    /* create threads to handle KNI, timers, NetLink etc */
+    ret = dpdk_threads_create();
+    if (ret != 0) {
+        dpdk_threads_cancel();
+        dpdk_threads_join();
+        vr_dpdk_host_exit();
+        dpdk_exit();
+        return ret;
+    }
+
+    /* run loops on all forwarding lcores */
+    ret = rte_eal_mp_remote_launch(vr_dpdk_lcore_launch, NULL, CALL_MASTER);
+
+    rte_eal_mp_wait_lcore();
+    dpdk_threads_cancel();
+    dpdk_threads_join();
+    dpdk_netlink_exit();
+    vr_dpdk_host_exit();
+    dpdk_exit();
+
+    return ret;
+}

--- a/dpdk/dpdk_vrouter.c
+++ b/dpdk/dpdk_vrouter.c
@@ -274,7 +274,7 @@ dpdk_timer_loop(__attribute__((unused)) void *dummy)
         rte_timer_manage();
 
         /* check for the global stop flag */
-        if (unlikely(rte_atomic16_read(&vr_dpdk.stop_flag)))
+        if (unlikely(vr_dpdk_is_stop_flag_set()))
             break;
 
         usleep(VR_DPDK_SLEEP_TIMER_US);
@@ -290,7 +290,7 @@ dpdk_kni_loop(__attribute__((unused)) void *dummy)
         vr_dpdk_knidev_all_handle();
 
         /* check for the global stop flag */
-        if (unlikely(rte_atomic16_read(&vr_dpdk.stop_flag)))
+        if (unlikely(vr_dpdk_is_stop_flag_set()))
             break;
 
         usleep(VR_DPDK_SLEEP_KNI_US);
@@ -305,7 +305,7 @@ dpdk_stop_flag_set(void) {
     struct vr_dpdk_lcore *lcore;
 
     /* check if the flag is already set */
-    if (unlikely(rte_atomic16_read(&vr_dpdk.stop_flag)))
+    if (unlikely(vr_dpdk_is_stop_flag_set()))
         return;
 
     RTE_LCORE_FOREACH(lcore_id) {
@@ -314,6 +314,16 @@ dpdk_stop_flag_set(void) {
     }
 
     rte_atomic16_inc(&vr_dpdk.stop_flag);
+}
+
+/* Check if the stop flag is set */
+int
+vr_dpdk_is_stop_flag_set(void)
+{
+    if (unlikely(rte_atomic16_read(&vr_dpdk.stop_flag)))
+        return -1;
+
+    return 0;
 }
 
 /* Custom handling of signals */

--- a/dpdk/dpdk_vrouter.c
+++ b/dpdk/dpdk_vrouter.c
@@ -457,14 +457,14 @@ main(int argc, char *argv[])
             return -1;
     }
 
-    /* Create user space vhost thread */
-    if ((ret = vr_uvhost_init(&vr_dpdk.uvh_thread, vr_dpdk_exit_trigger))) {
-        return ret;
-    }
-
     /* init DPDK first since vRouter uses DPDK mallocs and logs */
     ret = dpdk_init();
     if (ret != 0) {
+        return ret;
+    }
+
+    /* Create user space vhost thread */
+    if ((ret = vr_uvhost_init(&vr_dpdk.uvh_thread, vr_dpdk_exit_trigger))) {
         return ret;
     }
 

--- a/dpdk/dpdk_vrouter.c
+++ b/dpdk/dpdk_vrouter.c
@@ -263,7 +263,6 @@ dpdk_exit(void)
     if (pthread_mutex_destroy(&vr_dpdk.if_lock)) {
         RTE_LOG(ERR, VROUTER, "Error destroying interface lock\n");
     }
-    RTE_LOG(INFO, VROUTER, "Stopped.\n");
 }
 
 /* Timer handling loop */
@@ -300,7 +299,8 @@ dpdk_kni_loop(__attribute__((unused)) void *dummy)
 
 /* Set stop flag for all lcores */
 static void
-dpdk_stop_flag_set(void) {
+dpdk_stop_flag_set(void)
+{
     unsigned lcore_id;
     struct vr_dpdk_lcore *lcore;
 
@@ -522,5 +522,5 @@ main(int argc, char *argv[])
     vr_dpdk_host_exit();
     dpdk_exit();
 
-    return ret;
+    rte_exit(ret, "vRouter/DPDK is stopped.\n");
 }

--- a/dpdk/dpdk_vrouter.c
+++ b/dpdk/dpdk_vrouter.c
@@ -127,21 +127,20 @@ dpdk_mempools_create(void)
  *
  * Returns:
  *      new core mask on success
- *      VR_DPDK_LCORE_MASK on failure
+ *      VR_DPDK_DEF_LCORE_MASK on failure
  */
 static uint64_t
 dpdk_core_mask_get(void) {
     cpu_set_t cs;
     uint64_t cpu_core_mask = 0;
     int i;
-    unsigned int cpu_core_mask_ones, vr_dpdk_lcore_mask_ones;
 
     /*
      * If it is impossible to get the cpu_set_t structure, return
-     * VR_DPDK_LCORE_MASK as a default value.
+     * VR_DPDK_DEF_LCORE_MASK as a default value.
      */
     if (sched_getaffinity(0, sizeof(cs), &cs) < 0)
-        return VR_DPDK_LCORE_MASK;
+        return VR_DPDK_DEF_LCORE_MASK;
 
     /*
      * Go through all the CPUs in the cpu_set_t structure to check
@@ -157,32 +156,9 @@ dpdk_core_mask_get(void) {
     }
 
     if(!cpu_core_mask)
-        return VR_DPDK_LCORE_MASK;
+        return VR_DPDK_DEF_LCORE_MASK;
 
-    /*
-     * After successfully building the affinity mask, we should return one of
-     * the following:
-     *
-     * return cpu_core_mask, if:
-     *      * we have as many CPUs (bits set) as in VR_DPDK_LCORE_MASK.
-     *      CPUs may have different affinity than set in the default mask
-     *      and we want to prioritize that setting.
-     *
-     *      * we have less CPUs than defined in VR_DPDK_LCORE_MASK.
-     *
-     * return (cpu_core_mask & VR_DPDK_LCORE_MASK), if:
-     *      * we have more CPUs (bits set) than defined in VR_DPDK_LCORE_MASK.
-     *      This will left some CPUs available for other tasks, eg. VMs.
-     */
-    cpu_core_mask_ones
-                = __builtin_popcountll((unsigned long long)cpu_core_mask);
-    vr_dpdk_lcore_mask_ones
-                = __builtin_popcountll((unsigned long long)VR_DPDK_LCORE_MASK);
-
-    if(cpu_core_mask_ones > vr_dpdk_lcore_mask_ones)
-        return (cpu_core_mask & VR_DPDK_LCORE_MASK);
-    else
-        return cpu_core_mask;
+    return cpu_core_mask;
 }
 
 /* Updates parameters of EAL initialization in dpdk_argv[]. */

--- a/dpdk/dpdk_vrouter.c
+++ b/dpdk/dpdk_vrouter.c
@@ -263,6 +263,7 @@ dpdk_exit(void)
     if (pthread_mutex_destroy(&vr_dpdk.if_lock)) {
         RTE_LOG(ERR, VROUTER, "Error destroying interface lock\n");
     }
+    RTE_LOG(INFO, VROUTER, "Stopped.\n");
 }
 
 /* Timer handling loop */
@@ -433,7 +434,8 @@ main(int argc, char *argv[])
 {
     int ret, opt, option_index;
 
-    fprintf(stdout, "vRouter/DPDK version: %s\n", ContrailBuildInfo);
+    fprintf(stdout, "Starting vRouter/DPDK...\nBuild information: %s\n",
+                ContrailBuildInfo);
     fflush(stdout);
 
     while ((opt = getopt_long(argc, argv, "", long_options, &option_index))

--- a/dpdk/qemu_uvhost.h
+++ b/dpdk/qemu_uvhost.h
@@ -1,0 +1,70 @@
+/*
+ * qemu_uvhost.h - header for structure and message definitions copied from
+ * qemu 2.1.
+ *
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+
+#ifndef __QEMU_UVHOST_H__
+#define __QEMU_UVHOST_H__
+
+#define VHOST_MEMORY_MAX_NREGIONS    8
+#define VHOST_CLIENT_MAX_VRINGS      2
+
+typedef enum VhostUserRequest {
+    VHOST_USER_NONE = 0,
+    VHOST_USER_GET_FEATURES = 1,
+    VHOST_USER_SET_FEATURES = 2,
+    VHOST_USER_SET_OWNER = 3,
+    VHOST_USER_RESET_OWNER = 4,
+    VHOST_USER_SET_MEM_TABLE = 5,
+    VHOST_USER_SET_LOG_BASE = 6,
+    VHOST_USER_SET_LOG_FD = 7,
+    VHOST_USER_SET_VRING_NUM = 8,
+    VHOST_USER_SET_VRING_ADDR = 9,
+    VHOST_USER_SET_VRING_BASE = 10,
+    VHOST_USER_GET_VRING_BASE = 11,
+    VHOST_USER_SET_VRING_KICK = 12,
+    VHOST_USER_SET_VRING_CALL = 13,
+    VHOST_USER_SET_VRING_ERR = 14,
+    VHOST_USER_MAX
+} VhostUserRequest;
+
+typedef struct VhostUserMemoryRegion {
+    uint64_t guest_phys_addr;
+    uint64_t memory_size;
+    uint64_t userspace_addr;
+    uint64_t mmap_offset;
+} VhostUserMemoryRegion;
+
+typedef struct VhostUserMemory {
+    uint32_t nregions;
+    uint32_t padding;
+    VhostUserMemoryRegion regions[VHOST_MEMORY_MAX_NREGIONS];
+} VhostUserMemory;
+
+typedef struct VhostUserMsg {
+    VhostUserRequest request;
+
+#define VHOST_USER_VERSION_MASK     (0x3)
+#define VHOST_USER_REPLY_MASK       (0x1<<2)
+    uint32_t flags;
+    uint32_t size; /* the following payload size */
+    union {
+#define VHOST_USER_VRING_IDX_MASK   (0xff)
+#define VHOST_USER_VRING_NOFD_MASK  (0x1<<8)
+        uint64_t u64;
+        struct vhost_vring_state state;
+        struct vhost_vring_addr addr;
+        VhostUserMemory memory;
+    };
+} __attribute__((packed)) VhostUserMsg;
+
+/*
+ * VHOST_USER_HSIZE - size of the header of the user space vhost message. This
+ * doesn't include the variable part of the message (union above).
+ */
+#define VHOST_USER_HSIZE (sizeof(VhostUserRequest) + (2 * sizeof(u_int32_t)))
+
+#endif /* __QEMU_UVHOST_H__ */
+

--- a/dpdk/vr_dpdk_ethdev.c
+++ b/dpdk/vr_dpdk_ethdev.c
@@ -1,0 +1,523 @@
+/*
+ * Copyright (C) 2014 Semihalf.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation version 2.
+ *
+ * This program is distributed "as is" WITHOUT ANY WARRANTY of any
+ * kind, whether express or implied; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * vr_dpdk_ethdev.c -- DPDK ethernet device
+ *
+ */
+#include <stdio.h>
+#include <unistd.h>
+
+#include "vr_dpdk.h"
+
+#include <rte_port_ethdev.h>
+#include <rte_errno.h>
+#include <rte_byteorder.h>
+
+static struct rte_eth_conf ethdev_conf = {
+    .link_speed = 0,    /* ETH_LINK_SPEED_10[0|00|000], or 0 for autonegotation */
+    .link_duplex = 0,   /* ETH_LINK_[HALF_DUPLEX|FULL_DUPLEX], or 0 for autonegotation */
+    .rxmode = { /* Port RX configuration. */
+        /* The multi-queue packet distribution mode to be used, e.g. RSS. */
+        .mq_mode            = ETH_MQ_RX_RSS,
+        .max_rx_pkt_len     = ETHER_MAX_LEN, /* Only used if jumbo_frame enabled */
+        .header_split       = 0, /* Disable Header Split */
+        .hw_ip_checksum     = 1, /* Enable IP/UDP/TCP checksum offload */
+        .hw_vlan_filter     = 0, /* Disabel VLAN filter */
+        .hw_vlan_strip      = 0, /* Disable VLAN strip */
+        .hw_vlan_extend     = 0, /* Disable Extended VLAN */
+        .jumbo_frame        = 0, /* Disable Jumbo Frame Receipt */
+        .hw_strip_crc       = 0, /* Disable CRC stripping by hardware */
+        .enable_scatter     = 0, /* Disable scatter packets rx handler */
+    },
+    .rx_adv_conf = {
+        .rss_conf = { /* Port RSS configuration */
+            .rss_key            = NULL, /* If not NULL, 40-byte hash key */
+            .rss_key_len        = 0,    /* Hash key length in bytes */
+            .rss_hf             = ETH_RSS_UDP, /* Hash functions to apply */
+        },
+    },
+    .txmode = { /* Port TX configuration. */
+        .mq_mode            = ETH_MQ_TX_NONE, /* TX multi-queues mode */
+        /* For i40e specifically */
+        .pvid               = 0,
+        .hw_vlan_reject_tagged      = 0, /* If set, reject sending out tagged pkts */
+        .hw_vlan_reject_untagged    = 0, /* If set, reject sending out untagged pkts */
+        .hw_vlan_insert_pvid        = 0, /* If set, enable port based VLAN insertion */
+    },
+    .fdir_conf = {
+#if VR_DPDK_USE_HW_FILTERING
+        .mode = RTE_FDIR_MODE_PERFECT,          /* Flow Director mode. */
+        .status = RTE_FDIR_REPORT_STATUS,       /* How to report FDIR hash. */
+#else
+        .mode = RTE_FDIR_MODE_NONE,
+        .status = RTE_FDIR_NO_REPORT_STATUS,
+#endif
+        .pballoc = RTE_FDIR_PBALLOC_64K,        /* Space for FDIR filters. */
+        /* Offset of flexbytes field in RX packets (in 16-bit word units). */
+        .flexbytes_offset = VR_DPDK_MPLS_OFFSET,
+        /* RX queue of packets matching a "drop" filter in perfect mode. */
+        .drop_queue = 0,
+    },
+};
+
+/* RX and TX Prefetch, Host, and Write-back threshold values should be
+ * carefully set for optimal performance. Consult the network
+ * controller's datasheet and supporting DPDK documentation for guidance
+ * on how these parameters should be set.
+ */
+/* RX ring configuration */
+static const struct rte_eth_rxconf rx_queue_conf = {
+    .rx_thresh = {
+        .pthresh = 8,   /* Ring prefetch threshold */
+        .hthresh = 8,   /* Ring host threshold */
+        .wthresh = 4,   /* Ring writeback threshold */
+    },
+    .rx_free_thresh = 0,    /* Immediately free RX descriptors */
+};
+
+/*
+ * These default values are optimized for use with the Intel(R) 82599 10 GbE
+ * Controller and the DPDK ixgbe PMD. Consider using other values for other
+ * network controllers and/or network drivers.
+ */
+/* TX ring configuration */
+static const struct rte_eth_txconf tx_queue_conf = {
+    .tx_thresh = {
+        .pthresh = 36,  /* Ring prefetch threshold */
+        .hthresh = 0,   /* Ring host threshold */
+        .wthresh = 0,   /* Ring writeback threshold */
+    },
+    .tx_free_thresh = 0,    /* Use PMD default values */
+    .tx_rs_thresh = 0,      /* Use PMD default values */
+    .txq_flags =            /* Set flags for the Tx queue */
+        ETH_TXQ_FLAGS_NOMULTSEGS
+        | ETH_TXQ_FLAGS_NOREFCOUNT
+        | ETH_TXQ_FLAGS_NOVLANOFFL
+        | ETH_TXQ_FLAGS_NOXSUMSCTP
+        | ETH_TXQ_FLAGS_NOXSUMTCP
+};
+
+/* Add hardware filter */
+int
+vr_dpdk_ethdev_filter_add(struct vr_interface *vif, uint16_t queue_id,
+    unsigned dst_ip, unsigned mpls_label)
+{
+    struct vr_dpdk_ethdev *ethdev = (struct vr_dpdk_ethdev *)vif->vif_os;
+    uint8_t port_id = ethdev->ethdev_port_id;
+    struct rte_fdir_filter filter;
+    int ret;
+
+    /* accept 2-byte labels only */
+    if (mpls_label > 0xffff)
+        return -EINVAL;
+
+    if (queue_id > VR_DPDK_MAX_NB_RX_QUEUES)
+        return -EINVAL;
+
+    memset(&filter, 0, sizeof(filter));
+    filter.iptype = RTE_FDIR_IPTYPE_IPV4;
+    filter.l4type = RTE_FDIR_L4TYPE_UDP;
+    filter.ip_dst.ipv4_addr = dst_ip;
+    filter.port_dst = rte_cpu_to_be_16((uint16_t)VR_MPLS_OVER_UDP_DST_PORT);
+    filter.flex_bytes = rte_cpu_to_be_16((uint16_t)mpls_label);
+
+    RTE_LOG(DEBUG, VROUTER, "%s: ip_dst=0x%x port_dst=%d flex_bytes=%d\n", __func__,
+        (unsigned)dst_ip, (unsigned)VR_MPLS_OVER_UDP_DST_PORT, (unsigned)mpls_label);
+
+    if (queue_id >= 0xFF) {
+        RTE_LOG(ERR, VROUTER, "\terror adding perfect filter for eth device %"
+                PRIu8 ": queue ID %" PRIu16 " is out of range\n",
+                 port_id, queue_id);
+        return -EINVAL;
+    }
+    ret = rte_eth_dev_fdir_add_perfect_filter(port_id, &filter, (uint16_t)mpls_label,
+        (uint8_t)queue_id, 0);
+    if (ret == 0)
+        ethdev->ethdev_queue_states[queue_id] = VR_DPDK_QUEUE_FILTERING_STATE;
+
+    return ret;
+}
+
+/* Get a ready queue ID */
+uint16_t
+vr_dpdk_ethdev_ready_queue_id_get(struct vr_interface *vif)
+{
+    uint16_t i;
+    struct vr_dpdk_ethdev *ethdev = (struct vr_dpdk_ethdev *)vif->vif_os;
+
+    for (i = ethdev->ethdev_nb_rss_queues; i < ethdev->ethdev_nb_rx_queues; i++) {
+        if (ethdev->ethdev_queue_states[i] == VR_DPDK_QUEUE_READY_STATE) {
+            return i;
+        }
+    }
+    return VR_DPDK_INVALID_QUEUE_ID;
+}
+
+/* Release ethdev RX queue */
+static void
+dpdk_ethdev_rx_queue_release(unsigned lcore_id, struct vr_interface *vif)
+{
+    struct vr_dpdk_lcore *lcore = vr_dpdk.lcores[lcore_id];
+    struct vr_dpdk_queue *rx_queue = &lcore->lcore_rx_queues[vif->vif_idx];
+    struct vr_dpdk_queue_params *rx_queue_params
+                        = &lcore->lcore_rx_queue_params[vif->vif_idx];
+
+    /* free the queue */
+    if (rx_queue->rxq_ops.f_free(rx_queue->q_queue_h)) {
+        RTE_LOG(ERR, VROUTER, "\terror freeing lcore %u eth device RX queue\n",
+                    lcore_id);
+    }
+
+    /* reset the queue */
+    vrouter_put_interface(rx_queue->q_vif);
+    memset(rx_queue, 0, sizeof(*rx_queue));
+    memset(rx_queue_params, 0, sizeof(*rx_queue_params));
+}
+
+/* Init eth RX queue */
+struct vr_dpdk_queue *
+vr_dpdk_ethdev_rx_queue_init(unsigned lcore_id, struct vr_interface *vif,
+    unsigned queue_or_lcore_id)
+{
+    uint16_t rx_queue_id = queue_or_lcore_id;
+    uint8_t port_id;
+    unsigned int vif_idx = vif->vif_idx;
+    const unsigned int socket_id = rte_lcore_to_socket_id(lcore_id);
+
+    struct vr_dpdk_ethdev *ethdev;
+    struct vr_dpdk_lcore *lcore = vr_dpdk.lcores[lcore_id];
+    struct vr_dpdk_queue *rx_queue = &lcore->lcore_rx_queues[vif_idx];
+    struct vr_dpdk_queue_params *rx_queue_params
+                    = &lcore->lcore_rx_queue_params[vif_idx];
+
+    ethdev = (struct vr_dpdk_ethdev *)vif->vif_os;
+    port_id = ethdev->ethdev_port_id;
+
+    /* init queue */
+    rx_queue->rxq_ops = rte_port_ethdev_reader_ops;
+    rx_queue->q_queue_h = NULL;
+    rx_queue->rxq_burst_size = VR_DPDK_ETH_RX_BURST_SZ;
+    rx_queue->q_vif = vrouter_get_interface(vif->vif_rid, vif_idx);
+
+    /* create the queue */
+    struct rte_port_ethdev_reader_params reader_params = {
+        .port_id = port_id,
+        .queue_id = rx_queue_id,
+    };
+    rx_queue->q_queue_h = rx_queue->rxq_ops.f_create(&reader_params, socket_id);
+    if (rx_queue->q_queue_h == NULL) {
+        RTE_LOG(ERR, VROUTER, "\terror creating eth device %" PRIu8
+                " RX queue %" PRIu16 "\n", port_id, rx_queue_id);
+        return NULL;
+    }
+
+    /* store queue params */
+    rx_queue_params->qp_release_op = &dpdk_ethdev_rx_queue_release;
+
+    return rx_queue;
+}
+
+/* Release ethdev TX queue */
+static void
+dpdk_ethdev_tx_queue_release(unsigned lcore_id, struct vr_interface *vif)
+{
+    struct vr_dpdk_lcore *lcore = vr_dpdk.lcores[lcore_id];
+    struct vr_dpdk_queue *tx_queue = &lcore->lcore_tx_queues[vif->vif_idx];
+    struct vr_dpdk_queue_params *tx_queue_params
+                        = &lcore->lcore_tx_queue_params[vif->vif_idx];
+
+    tx_queue->txq_ops.f_tx = NULL;
+    rte_wmb();
+
+    /* flush and free the queue */
+    if (tx_queue->txq_ops.f_free(tx_queue->q_queue_h)) {
+        RTE_LOG(ERR, VROUTER, "\terror freeing lcore %u eth device TX queue\n",
+                    lcore_id);
+    }
+
+    /* reset the queue */
+    vrouter_put_interface(tx_queue->q_vif);
+    memset(tx_queue, 0, sizeof(*tx_queue));
+    memset(tx_queue_params, 0, sizeof(*tx_queue_params));
+}
+
+/* Init eth TX queue */
+struct vr_dpdk_queue *
+vr_dpdk_ethdev_tx_queue_init(unsigned lcore_id, struct vr_interface *vif,
+    unsigned queue_or_lcore_id)
+{
+    uint16_t tx_queue_id = queue_or_lcore_id;
+    uint8_t port_id;
+    unsigned int vif_idx = vif->vif_idx;
+    const unsigned int socket_id = rte_lcore_to_socket_id(lcore_id);
+
+    struct vr_dpdk_ethdev *ethdev;
+    struct vr_dpdk_lcore *lcore = vr_dpdk.lcores[lcore_id];
+    struct vr_dpdk_queue *tx_queue = &lcore->lcore_tx_queues[vif_idx];
+    struct vr_dpdk_queue_params *tx_queue_params
+                    = &lcore->lcore_tx_queue_params[vif_idx];
+
+    ethdev = (struct vr_dpdk_ethdev *)vif->vif_os;
+    port_id = ethdev->ethdev_port_id;
+
+    /* init queue */
+    tx_queue->txq_ops = rte_port_ethdev_writer_ops;
+    tx_queue->q_queue_h = NULL;
+    tx_queue->q_vif = vrouter_get_interface(vif->vif_rid, vif_idx);
+
+    /* create the queue */
+    struct rte_port_ethdev_writer_params writer_params = {
+        .port_id = port_id,
+        .queue_id = tx_queue_id,
+        .tx_burst_sz = VR_DPDK_ETH_TX_BURST_SZ,
+    };
+    tx_queue->q_queue_h = tx_queue->txq_ops.f_create(&writer_params, socket_id);
+    if (tx_queue->q_queue_h == NULL) {
+        RTE_LOG(ERR, VROUTER, "\terror creating eth device %" PRIu8
+                " TX queue %" PRIu16 "\n", port_id, tx_queue_id);
+        return NULL;
+    }
+
+    /* store queue params */
+    tx_queue_params->qp_release_op = &dpdk_ethdev_tx_queue_release;
+
+    return tx_queue;
+}
+
+/* Update device info */
+static void
+dpdk_ethdev_info_update(struct vr_dpdk_ethdev *ethdev)
+{
+    struct rte_eth_dev_info dev_info;
+
+    rte_eth_dev_info_get(ethdev->ethdev_port_id, &dev_info);
+
+    ethdev->ethdev_nb_rx_queues = RTE_MIN(dev_info.max_rx_queues,
+        VR_DPDK_MAX_NB_RX_QUEUES);
+    ethdev->ethdev_nb_tx_queues = RTE_MIN(RTE_MIN(dev_info.max_tx_queues,
+        vr_dpdk.nb_fwd_lcores + 1), VR_DPDK_MAX_NB_TX_QUEUES);
+    ethdev->ethdev_nb_rss_queues = RTE_MIN(RTE_MIN(ethdev->ethdev_nb_rx_queues,
+        vr_dpdk.nb_fwd_lcores), VR_DPDK_MAX_NB_RSS_QUEUES);
+
+    RTE_LOG(DEBUG, VROUTER, "dev_info: driver_name=%s if_index=%u "
+            "max_rx_queues=%"PRIu16 "max_tx_queues=%"PRIu16
+            " max_vfs=%"PRIu16" max_vmdq_pools=%"PRIu16
+            " rx_offload_capa=%"PRIx32" tx_offload_capa=%"PRIx32"\n",
+            dev_info.driver_name, dev_info.if_index,
+            dev_info.max_rx_queues, dev_info.max_tx_queues,
+            dev_info.max_vfs, dev_info.max_vmdq_pools,
+            dev_info.rx_offload_capa, dev_info.tx_offload_capa);
+
+#if !VR_DPDK_USE_HW_FILTERING
+    /* use RSS queues only */
+    ethdev->ethdev_nb_rx_queues = ethdev->ethdev_nb_rss_queues;
+#endif
+
+    return;
+}
+
+/* Setup ethdev hardware queues */
+static int
+dpdk_ethdev_queues_setup(struct vr_dpdk_ethdev *ethdev)
+{
+    int ret, i;
+    uint8_t port_id = ethdev->ethdev_port_id;
+    struct rte_mempool *mempool;
+
+    /* configure RX queues */
+    RTE_LOG(DEBUG, VROUTER, "%s: nb_rx_queues=%u nb_tx_queues=%u\n",
+        __func__, (unsigned)ethdev->ethdev_nb_rx_queues,
+            (unsigned)ethdev->ethdev_nb_tx_queues);
+
+    for (i = 0; i < VR_DPDK_MAX_NB_RX_QUEUES; i++) {
+        if (i < ethdev->ethdev_nb_rss_queues) {
+            mempool = vr_dpdk.rss_mempool;
+            ethdev->ethdev_queue_states[i] = VR_DPDK_QUEUE_RSS_STATE;
+        } else if (i < ethdev->ethdev_nb_rx_queues) {
+            if (vr_dpdk.nb_free_mempools == 0) {
+                RTE_LOG(ERR, VROUTER, "\terror assigning mempool to eth device %"
+                    PRIu8 " RX queue %d\n", port_id, i);
+                return -ENOMEM;
+            }
+            vr_dpdk.nb_free_mempools--;
+            mempool = vr_dpdk.free_mempools[vr_dpdk.nb_free_mempools];
+            ethdev->ethdev_queue_states[i] = VR_DPDK_QUEUE_READY_STATE;
+        } else {
+            ethdev->ethdev_queue_states[i] = VR_DPDK_QUEUE_NONE;
+            continue;
+        }
+
+        ret = rte_eth_rx_queue_setup(port_id, i, VR_DPDK_NB_RXD,
+            rte_eth_dev_socket_id(port_id), &rx_queue_conf, mempool);
+        if (ret < 0) {
+            /* return mempool to the list */
+            if (mempool != vr_dpdk.rss_mempool)
+                vr_dpdk.nb_free_mempools++;
+            RTE_LOG(ERR, VROUTER, "\terror setting up eth device %" PRIu8 " RX queue %d"
+                    ": %s (%d)\n", port_id, i, rte_strerror(-ret), -ret);
+            return ret;
+        }
+        /* save queue mempool pointer */
+        ethdev->ethdev_mempools[i] = mempool;
+    }
+    i = ethdev->ethdev_nb_rx_queues - ethdev->ethdev_nb_rss_queues;
+    RTE_LOG(INFO, VROUTER, "\tsetup %d RSS queue(s) and %d filtering queue(s)\n",
+        (int)ethdev->ethdev_nb_rss_queues, i);
+
+    /* configure TX queues */
+    for (i = 0; i < ethdev->ethdev_nb_tx_queues; i++) {
+        ret = rte_eth_tx_queue_setup(port_id, i, VR_DPDK_NB_TXD,
+            rte_eth_dev_socket_id(port_id), &tx_queue_conf);
+        if (ret < 0) {
+            RTE_LOG(ERR, VROUTER, "\terror setting up eth device %" PRIu8 " TX queue %d"
+                    ": %s (%d)\n", port_id, i, rte_strerror(-ret), -ret);
+            return ret;
+        }
+    }
+    return 0;
+}
+
+/* Init RSS */
+int
+vr_dpdk_ethdev_rss_init(struct vr_dpdk_ethdev *ethdev)
+{
+    int ret, i, j;
+    uint8_t port_id = ethdev->ethdev_port_id;
+    struct rte_eth_rss_reta reta_conf;
+
+    /* create new RSS redirection table */
+    memset(&reta_conf, 0, sizeof(reta_conf));
+    for (i = j = 0; i < ETH_RSS_RETA_NUM_ENTRIES; i++) {
+        reta_conf.reta[i] = j++;
+        if (ethdev->ethdev_queue_states[j] != VR_DPDK_QUEUE_RSS_STATE)
+            j = 0;
+    }
+
+    /* update RSS redirection table */
+    reta_conf.mask_lo = reta_conf.mask_hi = 0xffffffffffffffffULL;
+    ret = rte_eth_dev_rss_reta_update(port_id, &reta_conf);
+
+    /* no error if the device does not support RETA configuration */
+    if (ret == -ENOTSUP)
+        return 0;
+
+    if (ret < 0) {
+        RTE_LOG(ERR, VROUTER, "\terror initializing ethdev %" PRIu8 " RSS: %s (%d)\n",
+            port_id, rte_strerror(-ret), -ret);
+    }
+
+    return ret;
+}
+
+/* Init hardware filtering */
+static void
+dpdk_ethdev_mempools_free(struct vr_dpdk_ethdev *ethdev)
+{
+    int i;
+
+    for (i = ethdev->ethdev_nb_rss_queues; i < ethdev->ethdev_nb_rx_queues; i++) {
+        if (ethdev->ethdev_mempools[i] != NULL
+            && ethdev->ethdev_mempools[i] != vr_dpdk.rss_mempool) {
+            vr_dpdk.free_mempools[vr_dpdk.nb_free_mempools++] =
+                ethdev->ethdev_mempools[i];
+            ethdev->ethdev_mempools[i] = NULL;
+            ethdev->ethdev_queue_states[i] = VR_DPDK_QUEUE_READY_STATE;
+        }
+    }
+}
+
+/* Init hardware filtering */
+int
+vr_dpdk_ethdev_filtering_init(struct vr_interface *vif,
+        struct vr_dpdk_ethdev *ethdev)
+{
+    int ret;
+    uint8_t port_id = ethdev->ethdev_port_id;
+    struct rte_fdir_masks masks;
+    struct rte_eth_fdir fdir_info;
+
+    /* probe Flow Director */
+    memset(&fdir_info, 0, sizeof(fdir_info));
+    ret = rte_eth_dev_fdir_get_infos(port_id, &fdir_info);
+    if (ret == 0) {
+        /* enable hardware filtering */
+        RTE_LOG(INFO, VROUTER, "\tenable hardware filtering for ethdev %"
+            PRIu8 "\n", port_id);
+        vif->vif_flags |= VIF_FLAG_FILTERING_OFFLOAD;
+    } else {
+        vif->vif_flags &= ~VIF_FLAG_FILTERING_OFFLOAD;
+        /* free filtering mempools */
+        dpdk_ethdev_mempools_free(ethdev);
+        /* the ethdev does not support hardware filtering - it's not an error */
+        return 0;
+    }
+
+    memset(&masks, 0, sizeof(masks));
+    masks.dst_ipv4_mask = 0xffffffff;
+    masks.dst_port_mask = 0xffff;
+    masks.flexbytes = 1;
+
+    ret = rte_eth_dev_fdir_set_masks(port_id, &masks);
+    if (ret < 0) {
+        RTE_LOG(ERR, VROUTER, "\terror setting ethdev %" PRIu8
+            " Flow Director masks: %s (%d)\n", port_id, rte_strerror(-ret), -ret);
+    }
+
+    return ret;
+}
+
+/* Init ethernet device */
+int
+vr_dpdk_ethdev_init(struct vr_dpdk_ethdev *ethdev)
+{
+    uint8_t port_id;
+    int ret;
+
+    port_id = ethdev->ethdev_port_id;
+    ethdev->ethdev_ptr = &rte_eth_devices[port_id];
+
+    dpdk_ethdev_info_update(ethdev);
+
+    ret = rte_eth_dev_configure(port_id, ethdev->ethdev_nb_rx_queues,
+        ethdev->ethdev_nb_tx_queues, &ethdev_conf);
+    if (ret < 0) {
+        RTE_LOG(ERR, VROUTER, "\terror configuring eth dev %" PRIu8
+                ": %s (%d)\n",
+            port_id, rte_strerror(-ret), -ret);
+        return ret;
+    }
+
+    ret = dpdk_ethdev_queues_setup(ethdev);
+    if (ret < 0)
+        return ret;
+
+    /* Promisc mode
+     * KNI generates random MACs for e1000e NICs, so we need this
+     * option enabled for the development on servers with those NICs
+     */
+#if VR_DPDK_ENABLE_PROMISC
+    rte_eth_promiscuous_enable(port_id);
+#endif
+
+    return 0;
+}
+
+/* Release ethernet device */
+int
+vr_dpdk_ethdev_release(struct vr_dpdk_ethdev *ethdev)
+{
+    ethdev->ethdev_ptr = NULL;
+
+    dpdk_ethdev_mempools_free(ethdev);
+
+    return 0;
+}

--- a/dpdk/vr_dpdk_flow_mem.c
+++ b/dpdk/vr_dpdk_flow_mem.c
@@ -1,0 +1,223 @@
+/*
+ * vr_dpdk_flow_mem.c -- memory allocation for flow table
+ *
+ * Copyright(c) 2014, Juniper Networks Inc.,
+ * All rights reserved
+ */
+#include <stdio.h>
+#include <string.h>
+#include <fcntl.h>
+#include <rte_errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+
+#include "vr_dpdk.h"
+
+#include "vr_btable.h"
+
+#define MAX_LINE_SIZE   128
+#define HPI_MAX         16
+#define MOUNT_TABLE     "/proc/mounts"
+
+struct vr_hugepage_info {
+    char *mnt;
+    size_t page_size;
+    size_t size;
+    uint32_t num_pages;
+} vr_hugepage_md[HPI_MAX];
+
+extern struct vr_btable *vr_flow_table;
+extern struct vr_btable *vr_oflow_table;
+extern unsigned char *vr_flow_path;
+
+static int
+vr_hugepage_info_init(void)
+{
+    unsigned int i = 0, multiple = 1;
+    char *str, *token;
+
+    char *dev, *mnt, *fs, *options, *size;
+    char *size_attr, *sys_hp_file;
+    FILE *fp = NULL, *sys_fp = NULL;
+    struct vr_hugepage_info *hp;
+
+    char line[MAX_LINE_SIZE];
+    char nr_pages[MAX_LINE_SIZE];
+
+
+    fp = fopen(MOUNT_TABLE, "r");
+    if (!fp)
+        return -errno;
+
+    while (fgets(line, MAX_LINE_SIZE, fp)) {
+        if (i >= HPI_MAX)
+            break;
+
+        if ((str = strstr(line, "hugetlbfs"))) {
+            hp = &vr_hugepage_md[i++];
+            dev = strtok(line, " ");
+            mnt = strtok(NULL, " ");
+            fs = strtok(NULL, " ");
+            options = strtok(NULL, " ");
+
+            RTE_SET_USED(fs);
+            RTE_SET_USED(dev);
+            RTE_SET_USED(token);
+
+            hp->mnt = malloc(strlen(mnt) + 1);
+            memcpy(hp->mnt, mnt, strlen(mnt) + 1);
+
+            if (strstr(options, "pagesize=1G")) {
+                hp->page_size = (1024 * 1024 * 1024);
+                sys_hp_file =
+                    "/sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages";
+            } else {
+                hp->page_size = (2 * 1024 * 1024);
+                sys_hp_file =
+                    "/sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages";
+            }
+
+            size = strstr(options, "size=");
+            if (size && (size != options) && (*(size - 1) != ','))
+                size = strstr(size + 1, "size=");
+
+            if (size && ((size == options) || (*(size - 1) == ','))) {
+                size += strlen("size=");
+                size = strtok(size, ",");
+                size_attr = size + strlen(size) - 1;
+                switch (*size_attr) {
+                case 'k':
+                case 'K':
+                    multiple = 1024;
+                    *size_attr = '\0';
+                    break;
+
+                case 'M':
+                case 'm':
+                    multiple = 1024 * 1024;
+                    *size_attr = '\0';
+                    break;
+
+                case 'G':
+                case 'g':
+                    multiple = 1024 * 1024 * 1024;
+                    *size_attr = '\0';
+                    break;
+                }
+
+                hp->size = strtoul(size, NULL, 0) * multiple;
+                hp->num_pages = hp->size / hp->page_size;
+            } else {
+                sys_fp = fopen(sys_hp_file, "r");
+                if (!sys_fp)
+                    goto exit_func;
+
+                str = fgets(nr_pages, MAX_LINE_SIZE, sys_fp);
+                if (str == NULL)
+                    goto exit_func;
+                hp->num_pages = strtoul(nr_pages, NULL, 0);
+                hp->size = hp->num_pages * hp->page_size;
+            }
+
+        }
+    }
+
+exit_func:
+    if (fp)
+        fclose(fp);
+
+    if (sys_fp)
+        fclose(sys_fp);
+
+    return 0;
+}
+
+int
+vr_dpdk_flow_mem_init(void)
+{
+    int ret, i, fd;
+    unsigned int num_sizes;
+    size_t size, flow_table_size;
+    struct vr_hugepage_info *hpi;
+    char *file_name, *touse_file_name = NULL;
+    struct stat f_stat;
+
+    RTE_SET_USED(num_sizes);
+
+    ret = vr_hugepage_info_init();
+    if (ret < 0) {
+        fprintf(stderr, "Error initializing hugepage info: %s (%d)\n",
+            rte_strerror(-ret), -ret);
+        return ret;
+    }
+
+    flow_table_size = VR_FLOW_TABLE_SIZE + VR_OFLOW_TABLE_SIZE;
+
+    for (i = 0; i < HPI_MAX; i++) {
+        hpi = &vr_hugepage_md[i];
+        if (!hpi->mnt)
+            continue;
+        file_name = malloc(strlen(hpi->mnt) + strlen("/flow") + 1);
+        sprintf(file_name, "%s/flow", hpi->mnt);
+        if (stat(file_name, &f_stat)) {
+            if (!touse_file_name) {
+                size = hpi->size;
+                if (size >= flow_table_size) {
+                    touse_file_name = file_name;
+                } else {
+                    free(file_name);
+                }
+            }
+        } else {
+            touse_file_name = file_name;
+            break;
+        }
+    }
+
+    if (touse_file_name) {
+        fd = open(touse_file_name, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+        if (fd == -1) {
+            fprintf(stderr, "Error opening file %s: %s (%d)\n",
+                touse_file_name, rte_strerror(errno), errno);
+            return -errno;
+        }
+        vr_dpdk.flow_table = mmap(NULL, flow_table_size, PROT_READ | PROT_WRITE,
+                MAP_SHARED, fd, 0);
+        if (vr_dpdk.flow_table == MAP_FAILED) {
+            fprintf(stderr, "Error mmapping file %s: %s (%d)\n",
+                touse_file_name, rte_strerror(errno), errno);
+            return -errno;
+        }
+        bzero(vr_dpdk.flow_table, flow_table_size);
+        vr_flow_path = (unsigned char *)touse_file_name;
+    }
+
+    if (!vr_dpdk.flow_table)
+        return -ENOMEM;
+
+    return 0;
+}
+
+int
+vr_dpdk_flow_init(void)
+{
+    struct iovec iov;
+
+    iov.iov_base = vr_dpdk.flow_table;
+    iov.iov_len = VR_FLOW_TABLE_SIZE;
+    vr_flow_table = vr_btable_attach(&iov, 1, sizeof(struct vr_flow_entry));
+    if (!vr_flow_table)
+        return -1;
+
+    iov.iov_base = ((unsigned char *)vr_dpdk.flow_table + VR_FLOW_TABLE_SIZE);
+    iov.iov_len = VR_OFLOW_TABLE_SIZE;
+    vr_oflow_table = vr_btable_attach(&iov, 1, sizeof(struct vr_flow_entry));
+    if (!vr_oflow_table)
+        return -1;
+
+    return 0;
+}

--- a/dpdk/vr_dpdk_flow_mem.c
+++ b/dpdk/vr_dpdk_flow_mem.c
@@ -192,7 +192,7 @@ vr_dpdk_flow_mem_init(void)
                 touse_file_name, rte_strerror(errno), errno);
             return -errno;
         }
-        bzero(vr_dpdk.flow_table, flow_table_size);
+        memset(vr_dpdk.flow_table, 0, flow_table_size);
         vr_flow_path = (unsigned char *)touse_file_name;
     }
 

--- a/dpdk/vr_dpdk_host.c
+++ b/dpdk/vr_dpdk_host.c
@@ -1,0 +1,1164 @@
+/*
+ * Copyright (C) 2014 Semihalf.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation version 2.
+ *
+ * This program is distributed "as is" WITHOUT ANY WARRANTY of any
+ * kind, whether express or implied; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * vr_dpdk_host.c -- DPDK vrouter module
+ *
+ */
+
+#include <stdarg.h>
+#include <sys/user.h>
+#include <linux/if_ether.h>
+
+#include <netinet/ip.h>
+#include <netinet/tcp.h>
+
+#include <urcu-qsbr.h>
+
+#include <rte_config.h>
+#include <rte_malloc.h>
+#include <rte_jhash.h>
+#include <rte_timer.h>
+#include <rte_cycles.h>
+#include <rte_errno.h>
+#include <rte_jhash.h>
+
+#include "vr_dpdk.h"
+#include "vr_sandesh.h"
+#include "vr_proto.h"
+#include "vr_hash.h"
+#include "vr_fragment.h"
+
+/* Max number of CPU */
+unsigned int vr_num_cpus = RTE_MAX_LCORE;
+/* Global init flag */
+static bool vr_host_inited = false;
+
+struct rcu_cb_data {
+    struct rcu_head rcd_rcu;
+    vr_defer_cb rcd_user_cb;
+    struct vrouter *rcd_router;
+    unsigned char rcd_user_data[0];
+};
+
+static void *
+dpdk_page_alloc(unsigned int size)
+{
+    return rte_malloc(0, size, PAGE_SIZE);
+}
+
+static void
+dpdk_page_free(void *address, unsigned int size)
+{
+    rte_free(address);
+}
+
+static int
+dpdk_printf(const char *format, ...)
+{
+    va_list args;
+
+    rte_log(RTE_LOG_INFO, RTE_LOGTYPE_VROUTER, "DPCORE: ");
+    va_start(args, format);
+    rte_vlog(RTE_LOG_INFO, RTE_LOGTYPE_VROUTER, format, args);
+    va_end(args);
+
+    return 0;
+}
+
+static void *
+dpdk_malloc(unsigned int size)
+{
+    return rte_malloc(NULL, size, 0);
+}
+
+static void *
+dpdk_zalloc(unsigned int size)
+{
+    return rte_calloc(NULL, size, 1, 0);
+}
+
+static void
+dpdk_free(void *mem)
+{
+    rte_free(mem);
+}
+
+static uint64_t
+dpdk_vtop(void *address)
+{
+    /* TODO: not used */
+    rte_panic("%s: not used in DPDK mode\n", __func__);
+
+    return (uint64_t)0;
+}
+
+static struct vr_packet *
+dpdk_palloc(unsigned int size)
+{
+    struct rte_mbuf *m;
+
+    /* in DPDK we have fixed-sized mbufs only */
+    RTE_VERIFY(size < VR_DPDK_MAX_PACKET_SZ);
+    m = rte_pktmbuf_alloc(vr_dpdk.rss_mempool);
+    if (!m)
+        return (NULL);
+
+    return vr_dpdk_packet_get(m, NULL);
+}
+
+static struct vr_packet *
+dpdk_palloc_head(struct vr_packet *pkt, unsigned int size)
+{
+    /* TODO: not implemented */
+    fprintf(stderr, "%s: not implemented\n", __func__);
+    return NULL;
+}
+
+static struct vr_packet *
+dpdk_pexpand_head(struct vr_packet *pkt, unsigned int hspace)
+{
+    /* TODO: not implemented */
+    return pkt;
+}
+
+static void
+dpdk_pfree(struct vr_packet *pkt, unsigned short reason)
+{
+    struct vrouter *router = vrouter_get(0);
+    struct rte_mbuf *m;
+
+    if (!pkt)
+        rte_panic("Null packet");
+
+    if (router)
+        ((uint64_t *)(router->vr_pdrop_stats[pkt->vp_cpu]))[reason]++;
+
+    /* Fetch original mbuf from packet structure */
+    m = vr_dpdk_pkt_to_mbuf(pkt);
+    rte_pktmbuf_free(m);
+
+    return;
+}
+
+static void
+dpdk_preset(struct vr_packet *pkt)
+{
+    struct rte_mbuf *m;
+
+    if (!pkt)
+        rte_panic("%s: NULL pkt", __func__);
+
+    m = vr_dpdk_pkt_to_mbuf(pkt);
+
+    /* Reset packet data */
+    pkt->vp_data = rte_pktmbuf_headroom(m);
+    pkt->vp_tail = rte_pktmbuf_headroom(m) + rte_pktmbuf_data_len(m);
+    pkt->vp_len = rte_pktmbuf_data_len(m);
+
+    return;
+}
+
+/**
+ * Copy packet mbuf data to another packet mbuf.
+*
+ * @param dst
+ *   The destination packet mbuf.
+ * @param src
+ *   The source packet mbuf.
+ */
+
+static inline void
+dpdk_pktmbuf_copy_data(struct rte_mbuf *dst, struct rte_mbuf *src)
+{
+    dst->ol_flags = src->ol_flags;
+
+    dst->pkt.next = NULL;
+    dst->pkt.data_len = src->pkt.data_len;
+    dst->pkt.nb_segs = 1;
+    dst->pkt.in_port = src->pkt.in_port;
+    dst->pkt.pkt_len = src->pkt.data_len;
+    dst->pkt.vlan_macip = src->pkt.vlan_macip;
+    dst->pkt.hash = src->pkt.hash;
+
+    __rte_mbuf_sanity_check(dst, RTE_MBUF_PKT, 1);
+    __rte_mbuf_sanity_check(src, RTE_MBUF_PKT, 0);
+
+    /* copy data */
+    rte_memcpy(dst->pkt.data, src->pkt.data, src->pkt.data_len);
+}
+
+/**
+ * Creates a copy of the given packet mbuf.
+ *
+ * Walks through all segments of the given packet mbuf, and for each of them:
+ *  - Creates a new packet mbuf from the given pool.
+ *  - Copies data to the newly created mbuf.
+ * Then updates pkt_len and nb_segs of the "copy" packet mbuf to match values
+ * from the original packet mbuf.
+ *
+ * @param md
+ *   The packet mbuf to be copied.
+ * @param mp
+ *   The mempool from which the "copy" mbufs are allocated.
+ * @return
+ *   - The pointer to the new "copy" mbuf on success.
+ *   - NULL if allocation fails.
+ */
+static inline struct rte_mbuf *
+dpdk_pktmbuf_copy(struct rte_mbuf *md,
+        struct rte_mempool *mp)
+{
+    struct rte_mbuf *mc, *mi, **prev;
+    uint32_t pktlen;
+    uint8_t nseg;
+
+    if (unlikely ((mc = rte_pktmbuf_alloc(mp)) == NULL))
+        return (NULL);
+
+    mi = mc;
+    prev = &mi->pkt.next;
+    pktlen = md->pkt.pkt_len;
+    nseg = 0;
+
+    do {
+        nseg++;
+        dpdk_pktmbuf_copy_data(mi, md);
+        *prev = mi;
+        prev = &mi->pkt.next;
+    } while ((md = md->pkt.next) != NULL &&
+        (mi = rte_pktmbuf_alloc(mp)) != NULL);
+
+    *prev = NULL;
+    mc->pkt.nb_segs = nseg;
+    mc->pkt.pkt_len = pktlen;
+
+    /* Allocation of new indirect segment failed */
+    if (unlikely (mi == NULL)) {
+        rte_pktmbuf_free(mc);
+        return (NULL);
+    }
+
+    __rte_mbuf_sanity_check(mc, RTE_MBUF_PKT, 1);
+    return (mc);
+}
+
+/* VRouter callback */
+static struct vr_packet *
+dpdk_pclone(struct vr_packet *pkt)
+{
+    /* TODO: pktmbuf_clone version should be faster, but at the moment
+     *       vr_dpdk_mbuf_to_pkt returns original vr_packet structure
+     */
+#if 0
+    struct rte_mbuf *m, *m_clone;
+    struct vr_packet *pkt_clone;
+
+    m = vr_dpdk_pkt_to_mbuf(pkt);
+
+    m_clone = rte_pktmbuf_clone(m, vr_dpdk.rss_mempool);
+    if (!m_clone)
+        return NULL;
+
+    /* clone vr_packet data */
+    pkt_clone = vr_dpdk_mbuf_to_pkt(m_clone);
+    /* TODO: vr_dpdk_mbuf_to_pkt never returns pointer to the vr_packet copy */
+    *pkt_clone = *pkt;
+
+    return pkt_clone;
+#else
+    /* if no scatter/gather enabled -> just copy the mbuf */
+    struct rte_mbuf *m, *m_copy;
+    struct vr_packet *pkt_copy;
+
+    m = vr_dpdk_pkt_to_mbuf(pkt);
+
+    m_copy = dpdk_pktmbuf_copy(m, vr_dpdk.rss_mempool);
+    if (!m_copy)
+        return NULL;
+
+    /* copy vr_packet data */
+    pkt_copy = vr_dpdk_mbuf_to_pkt(m_copy);
+    *pkt_copy = *pkt;
+    /* set head pointer to a copy */
+    pkt_copy->vp_head = m_copy->buf_addr;
+
+    return pkt_copy;
+#endif
+}
+
+/* Copy the specified number of bytes from the source mbuf to the
+ * destination buffer.
+ */
+static int
+dpdk_pktmbuf_copy_bits(const struct rte_mbuf *mbuf, int offset,
+    void *to, int len)
+{
+    /* how many bytes to copy in loop */
+    int copy = 0;
+    /* loop pointer to a source data */
+    void *from;
+
+    /* check total packet length */
+    if (unlikely(offset > (int)rte_pktmbuf_pkt_len(mbuf) - len))
+        goto fault;
+
+    do {
+        if (offset < rte_pktmbuf_data_len(mbuf)) {
+            /* copy a piece of data */
+            from = (void *)(rte_pktmbuf_mtod(mbuf, uintptr_t) + offset);
+            copy = rte_pktmbuf_data_len(mbuf) - offset;
+            if (copy > len)
+                copy = len;
+            rte_memcpy(to, from, copy);
+            offset = 0;
+        } else {
+            offset -= rte_pktmbuf_data_len(mbuf);
+        }
+        /* get next mbuf */
+        to += copy;
+        len -= copy;
+        mbuf = mbuf->pkt.next;
+    } while (unlikely(len > 0 && NULL != mbuf));
+
+    if (likely(0 == len))
+        return 0;
+
+fault:
+    return -EFAULT;
+}
+
+/* VRouter callback */
+static int
+dpdk_pcopy(unsigned char *dst, struct vr_packet *p_src,
+    unsigned int offset, unsigned int len)
+{
+    int ret;
+    struct rte_mbuf *src;
+
+    src = vr_dpdk_pkt_to_mbuf(p_src);
+    ret = dpdk_pktmbuf_copy_bits(src, offset, dst, len);
+    if (ret)
+        return ret;
+
+    return len;
+}
+
+
+static unsigned short
+dpdk_pfrag_len(struct vr_packet *pkt)
+{
+    struct rte_mbuf *m;
+
+    m = vr_dpdk_pkt_to_mbuf(pkt);
+
+    return rte_pktmbuf_pkt_len(m) - rte_pktmbuf_data_len(m);
+}
+
+static unsigned short
+dpdk_phead_len(struct vr_packet *pkt)
+{
+    struct rte_mbuf *m;
+
+    m = vr_dpdk_pkt_to_mbuf(pkt);
+
+    return rte_pktmbuf_data_len(m);
+}
+
+static void
+dpdk_pset_data(struct vr_packet *pkt, unsigned short offset)
+{
+    struct rte_mbuf *m;
+
+    m = vr_dpdk_pkt_to_mbuf(pkt);
+    m->pkt.data = pkt->vp_head + offset;
+
+    return;
+}
+
+static unsigned int
+dpdk_get_cpu(void)
+{
+    return rte_lcore_id();
+}
+
+/* DPDK timer callback */
+static void
+dpdk_timer(struct rte_timer *tim, void *arg)
+{
+    struct vr_timer *vtimer = (struct vr_timer*)arg;
+
+    vtimer->vt_timer(vtimer->vt_vr_arg);
+}
+
+static int
+dpdk_create_timer(struct vr_timer *vtimer)
+{
+    struct rte_timer *timer;
+    uint64_t hz, ticks;
+
+    timer = rte_zmalloc("vr_dpdk_timer", sizeof(struct rte_timer), 0);
+
+    if (!timer) {
+        RTE_LOG(ERR, VROUTER, "Error allocating RTE timer\n");
+        return -1;
+    }
+
+    /* init timer */
+    rte_timer_init(timer);
+    vtimer->vt_os_arg = (void *)timer;
+
+    /* reset timer */
+    hz = rte_get_timer_hz();
+    ticks = hz * vtimer->vt_msecs / 1000;
+    if (rte_timer_reset(timer, ticks, PERIODICAL, rte_get_master_lcore(),
+        dpdk_timer, vtimer) == -1) {
+        RTE_LOG(ERR, VROUTER, "Error resetting timer\n");
+        rte_free(timer);
+
+        return -1;
+    }
+
+    return 0;
+}
+
+static void
+dpdk_delete_timer(struct vr_timer *vtimer)
+{
+    struct rte_timer *timer = (struct rte_timer*)vtimer->vt_os_arg;
+
+    if (timer) {
+        rte_timer_stop_sync(timer);
+        rte_free(timer);
+    } else {
+        RTE_LOG(ERR, VROUTER, "No timer to delete\n");
+    }
+}
+
+static void
+dpdk_get_time(unsigned int *sec, unsigned int *nsec)
+{
+    struct timespec ts;
+
+    *sec = *nsec = 0;
+    if (-1 == clock_gettime(CLOCK_REALTIME, &ts))
+        return;
+
+    *sec = ts.tv_sec;
+    *nsec = ts.tv_nsec;
+
+    return;
+}
+
+static void
+dpdk_get_mono_time(unsigned int *sec, unsigned int *nsec)
+{
+    struct timespec ts;
+
+    *sec = *nsec = 0;
+    if (-1 == clock_gettime(CLOCK_MONOTONIC, &ts))
+        return;
+
+    *sec = ts.tv_sec;
+    *nsec = ts.tv_nsec;
+
+    return;
+}
+
+static void
+dpdk_work_timer(struct rte_timer *timer, void *arg)
+{
+    struct vr_timer *vtimer = (struct vr_timer *)arg;
+
+    dpdk_timer(timer, arg);
+
+    dpdk_delete_timer(vtimer);
+    dpdk_free(vtimer);
+
+    return;
+}
+
+static void
+dpdk_schedule_work(unsigned int cpu, void (*fn)(void *), void *arg)
+{
+    uint64_t hz, ticks;
+
+    struct rte_timer *timer;
+    struct vr_timer *vtimer;
+
+    hz = rte_get_timer_hz();
+    ticks = hz / 10000;
+
+    timer = dpdk_malloc(sizeof(struct rte_timer));
+    if (!timer) {
+        RTE_LOG(ERR, VROUTER, "Error allocating RTE timer\n");
+        return;
+    }
+
+    vtimer = dpdk_malloc(sizeof(*vtimer));
+    if (!vtimer) {
+        dpdk_free(timer);
+        RTE_LOG(ERR, VROUTER, "Error allocating VR timer for work\n");
+        return;
+    }
+    vtimer->vt_timer = fn;
+    vtimer->vt_vr_arg = arg;
+    vtimer->vt_os_arg = timer;
+    vtimer->vt_msecs = ticks * 1000;
+
+    rte_timer_init(timer);
+
+    if (rte_timer_reset(timer, ticks, SINGLE, rte_lcore_id(),
+        dpdk_work_timer, vtimer) == -1) {
+        RTE_LOG(ERR, VROUTER, "Error resetting timer\n");
+        rte_free(timer);
+        rte_free(vtimer);
+
+        return;
+    }
+
+    return;
+}
+
+static void
+dpdk_delay_op(void)
+{
+    synchronize_rcu();
+
+    return;
+}
+
+static void
+rcu_cb(struct rcu_head *rh)
+{
+    struct rcu_cb_data *cb_data = (struct rcu_cb_data *)rh;
+
+    /* Call the user call back */
+    cb_data->rcd_user_cb(cb_data->rcd_router, cb_data->rcd_user_data);
+    dpdk_free(cb_data);
+
+    return;
+}
+
+static void
+dpdk_defer(struct vrouter *router, vr_defer_cb user_cb, void *data)
+{
+    struct rcu_cb_data *cb_data;
+
+    cb_data = CONTAINER_OF(rcd_user_data, struct rcu_cb_data, data);
+    cb_data->rcd_user_cb = user_cb;
+    cb_data->rcd_router = router;
+    call_rcu(&cb_data->rcd_rcu, rcu_cb);
+
+    return;
+}
+
+static void *
+dpdk_get_defer_data(unsigned int len)
+{
+    struct rcu_cb_data *cb_data;
+
+    if (!len)
+        return NULL;
+
+    cb_data = dpdk_malloc(sizeof(*cb_data) + len);
+    if (!cb_data) {
+        return NULL;
+    }
+
+    return cb_data->rcd_user_data;
+}
+
+static void
+dpdk_put_defer_data(void *data)
+{
+    struct rcu_cb_data *cb_data;
+
+    if (!data)
+        return;
+
+    cb_data = CONTAINER_OF(rcd_user_data, struct rcu_cb_data, data);
+    dpdk_free(cb_data);
+
+    return;
+}
+
+static void *
+dpdk_network_header(struct vr_packet *pkt)
+{
+    if (pkt->vp_network_h < pkt->vp_end)
+        return pkt->vp_head + pkt->vp_network_h;
+
+    /* TODO: for buffer chain? */
+    rte_panic("%s: buffer chain not supported\n", __func__);
+
+    return NULL;
+}
+
+static void *
+dpdk_inner_network_header(struct vr_packet *pkt)
+{
+    /* TODO: not used? */
+    rte_panic("%s: not implemented\n", __func__);
+
+    return NULL;
+}
+
+static void *
+dpdk_data_at_offset(struct vr_packet *pkt, unsigned short off)
+{
+    if (off < pkt->vp_end)
+        return pkt->vp_head + off;
+
+    /* TODO: for buffer chain? */
+    rte_panic("%s: buffer chain not supported\n", __func__);
+
+    return NULL;
+}
+
+/*
+ * dpdk_pheader_pointer
+ * return pointer to data at pkt->vp_data offset if hdr_len bytes
+ * in continuous memory, otherwise copy data to buf
+ */
+static void *
+dpdk_pheader_pointer(struct vr_packet *pkt, unsigned short hdr_len, void *buf)
+{
+    struct rte_mbuf *m;
+    int offset;
+
+    m = vr_dpdk_pkt_to_mbuf(pkt);
+
+    /*
+     * vp_data is offset from start of buffer,
+     * so first calculate offset from start of mbuf payload
+     */
+    offset = pkt->vp_data - rte_pktmbuf_headroom(m);
+    if ((offset + hdr_len) < rte_pktmbuf_data_len(m))
+        return (void *)((uintptr_t)m->buf_addr + pkt->vp_data);
+    else {
+        int len = rte_pktmbuf_data_len(m) - offset;
+        void *tmp_buf = buf;
+
+        rte_memcpy(tmp_buf, rte_pktmbuf_mtod(m, char *) + offset, len);
+        hdr_len -= len;
+        tmp_buf = (void *)((uintptr_t)tmp_buf + len);
+
+        /* iterate thru buffers chain */
+        while (hdr_len) {
+            m = m->pkt.next;
+            if (!m)
+                return (NULL);
+            if (hdr_len > rte_pktmbuf_data_len(m))
+                len = rte_pktmbuf_data_len(m);
+            else
+                len = hdr_len;
+
+            rte_memcpy(tmp_buf, rte_pktmbuf_mtod(m, void *), len);
+
+            tmp_buf = (void *)((uintptr_t)tmp_buf + len);
+            hdr_len -= len;
+        }
+
+        return (buf);
+    }
+}
+
+/* VRouter callback */
+static int
+dpdk_pcow(struct vr_packet *pkt, unsigned short head_room)
+{
+    struct rte_mbuf *mbuf = vr_dpdk_pkt_to_mbuf(pkt);
+
+    /* Store the right values to mbuf */
+    mbuf->pkt.data = pkt_data(pkt);
+    mbuf->pkt.pkt_len = pkt_len(pkt);
+    mbuf->pkt.data_len = pkt_head_len(pkt);
+
+    if (head_room > rte_pktmbuf_headroom(mbuf)) {
+        return -ENOMEM;
+    }
+
+    return 0;
+}
+
+/*
+ * dpdk_get_udp_src_port - return a source port for the outer UDP header.
+ * The source port is based on a hash of the inner IP source/dest addresses,
+ * vrf (and inner TCP/UDP ports in the future). The label from fmd
+ * will be used in the future to detect whether it is a L2/L3 packet.
+ * Returns 0 on error, valid source port otherwise.
+ *
+ * Based on linux/vrouter_mod.c:lh_get_udp_src_port
+ * Copyright (c) 2013, 2014 Juniper Networks, Inc.
+ */
+static uint16_t
+dpdk_get_udp_src_port(struct vr_packet *pkt, struct vr_forwarding_md *fmd,
+    unsigned short vrf)
+{
+    struct rte_mbuf *mbuf = vr_dpdk_pkt_to_mbuf(pkt);
+    unsigned int pull_len;
+    uint32_t ip_src, ip_dst, hashval, port_range;
+    struct vr_ip *iph;
+    uint16_t port;
+    uint16_t sport = 0, dport = 0;
+    struct vr_fragment *frag;
+    struct vrouter *router = vrouter_get(0);
+    uint32_t hash_key[5];
+    uint16_t *l4_hdr;
+    struct vr_flow_entry *fentry;
+
+    if (hashrnd_inited == 0) {
+        vr_hashrnd = random();
+        hashrnd_inited = 1;
+    }
+
+    if (pkt->vp_type == VP_TYPE_IP) {
+        /* Ideally the below code is only for VP_TYPE_IP and not
+         * for IP6. But having explicit check for IP only break IP6
+         */
+        pull_len = sizeof(struct iphdr);
+        pull_len += pkt_get_network_header_off(pkt);
+        pull_len -= rte_pktmbuf_headroom(mbuf);
+
+        /* It's safe to assume the ip hdr is within this mbuf, so we skip
+         * all the header checks.
+         */
+
+        iph = (struct vr_ip *)(mbuf->buf_addr + pkt_get_network_header_off(pkt));
+        if (vr_ip_transport_header_valid(iph)) {
+            if ((iph->ip_proto == VR_IP_PROTO_TCP) ||
+                        (iph->ip_proto == VR_IP_PROTO_UDP)) {
+                l4_hdr = (__u16 *) (((char *) iph) + (iph->ip_hl * 4));
+                sport = *l4_hdr;
+                dport = *(l4_hdr+1);
+            }
+        } else {
+            /*
+             * If this fragment required flow lookup, get the source and
+             * dst port from the frag entry. Otherwise, use 0 as the source
+             * dst port (which could result in fragments getting a different
+             * outer UDP source port than non-fragments in the same flow).
+             */
+            frag = vr_fragment_get(router, vrf, iph);
+            if (frag) {
+                sport = frag->f_sport;
+                dport = frag->f_dport;
+            }
+        }
+
+        if (fmd && fmd->fmd_flow_index >= 0) {
+            fentry = vr_get_flow_entry(router, fmd->fmd_flow_index);
+            if (fentry) {
+                vr_dpdk_mbuf_reset(pkt);
+                return fentry->fe_udp_src_port;
+            }
+        }
+
+        ip_src = iph->ip_saddr;
+        ip_dst = iph->ip_daddr;
+
+        hash_key[0] = ip_src;
+        hash_key[1] = ip_dst;
+        hash_key[2] = vrf;
+        hash_key[3] = sport;
+        hash_key[4] = dport;
+
+        hashval = rte_jhash(hash_key, 20, vr_hashrnd);
+        vr_dpdk_mbuf_reset(pkt);
+    } else {
+
+        /* We treat all non-ip packets as L2 here. For V6 we can extract
+         * the required fieleds explicity and manipulate the src port
+         */
+
+        if (pkt_head_len(pkt) < ETH_HLEN)
+            goto error;
+
+        hashval = vr_hash(pkt_data(pkt), ETH_HLEN, vr_hashrnd);
+        /* Include the VRF to calculate the hash */
+        hashval = vr_hash_2words(hashval, vrf, vr_hashrnd);
+    }
+
+
+    /*
+     * Convert the hash value to a value in the port range that we want
+     * for dynamic UDP ports
+     */
+    port_range = VR_MUDP_PORT_RANGE_END - VR_MUDP_PORT_RANGE_START;
+    port = (uint16_t) (((uint64_t) hashval * port_range) >> 32);
+
+    if (port > port_range) {
+        /*
+         * Shouldn't happen...
+         */
+        port = 0;
+    }
+
+    return (port + VR_MUDP_PORT_RANGE_START);
+
+error:
+    vr_dpdk_mbuf_reset(pkt);
+    return 0;
+}
+
+static void
+dpdk_adjust_tcp_mss(struct tcphdr *tcph, struct rte_mbuf *m, unsigned short overlay_len)
+{
+    int opt_off = sizeof(struct tcphdr);
+    u_int8_t *opt_ptr = (u_int8_t *) tcph;
+    u_int16_t pkt_mss, max_mss, mtu;
+    unsigned int csum;
+    uint8_t port_id;
+    struct vrouter *router = vrouter_get(0);
+
+    if ((tcph == NULL) || !(tcph->syn) || (router == NULL))
+        return;
+
+    if (router->vr_eth_if == NULL)
+        return;
+
+    while (opt_off < (tcph->doff * 4)) {
+        switch (opt_ptr[opt_off]) {
+        case TCPOPT_EOL:
+            return;
+
+        case TCPOPT_NOP:
+            opt_off++;
+            continue;
+
+        case TCPOPT_MAXSEG:
+            if ((opt_off + TCPOLEN_MAXSEG) > (tcph->doff*4))
+                return;
+
+            if (opt_ptr[opt_off+1] != TCPOLEN_MAXSEG)
+                return;
+
+            pkt_mss = (opt_ptr[opt_off+2] << 8) | opt_ptr[opt_off+3];
+            if (router->vr_eth_if == NULL)
+                return;
+
+            port_id = (((struct vr_dpdk_ethdev *)(router->vr_eth_if->vif_os))->
+                    ethdev_port_id);
+            rte_eth_dev_get_mtu(port_id, &mtu);
+
+            max_mss = mtu - (overlay_len + sizeof(struct vr_ip) +
+                sizeof(struct tcphdr));
+
+            if (pkt_mss > max_mss) {
+                opt_ptr[opt_off+2] = (max_mss & 0xff00) >> 8;
+                opt_ptr[opt_off+3] = max_mss & 0xff;
+
+                /* Recalculate checksum */
+                csum = (unsigned short)(~ntohs(tcph->check));
+                csum = csum + (unsigned short)~pkt_mss;
+                csum = (csum & 0xffff) + (csum >> 16);
+                csum += max_mss;
+                csum = (csum & 0xffff) + (csum >> 16);
+                tcph->check = htons(~((unsigned short)csum));
+            }
+            return;
+
+        default:
+            if ((opt_off + 1) == (tcph->doff*4))
+            return;
+
+            if (opt_ptr[opt_off+1])
+                opt_off += opt_ptr[opt_off+1];
+            else
+                opt_off++;
+
+            continue;
+        } /* switch */
+    } /* while */
+
+    return;
+}
+
+/*
+ * dpdk_pkt_from_vm_tcp_mss_adj - perform TCP MSS adjust, if required, for packets
+ * that are sent by a VM. Returns 0 on success, non-zero otherwise.
+ */
+static int
+dpdk_pkt_from_vm_tcp_mss_adj(struct vr_packet *pkt, unsigned short overlay_len)
+{
+    struct rte_mbuf *m;
+    struct vr_ip *iph;
+    struct tcphdr *tcph;
+    int offset;
+
+    m = vr_dpdk_pkt_to_mbuf(pkt);
+
+    /* check if whole ip header is in the packet */
+    offset = sizeof(struct vr_ip);
+    if (pkt->vp_data + offset < pkt->vp_end)
+        iph = (struct vr_ip *) ((uintptr_t)m->buf_addr + pkt->vp_data);
+    else
+        rte_panic("%s: ip header not in first buffer\n", __func__);
+
+    if (iph->ip_proto != VR_IP_PROTO_TCP)
+        goto out;
+
+    /*
+     * If this is a fragment and not the first one, it can be ignored
+     */
+    if (iph->ip_frag_off & htons(IP_OFFMASK))
+        goto out;
+
+
+    /*
+     * Now we know exact ip header length,
+     * check if whole tcp header is also in the packet
+     */
+    offset = (iph->ip_hl * 4) + sizeof(struct tcphdr);
+
+    if (pkt->vp_data + offset < pkt->vp_end)
+        tcph = (struct tcphdr *) ((char *) iph + (iph->ip_hl * 4));
+    else
+        rte_panic("%s: tcp header not in first buffer\n", __func__);
+
+    if ((tcph->doff << 2) <= (sizeof(struct tcphdr))) {
+        /*Nothing to do if there are no TCP options */
+        goto out;
+    }
+
+
+    offset += (tcph->doff << 2) - sizeof(struct tcphdr);
+    if (pkt->vp_data + offset > pkt->vp_end)
+        rte_panic("%s: tcp header outside first buffer\n", __func__);
+
+
+    dpdk_adjust_tcp_mss(tcph, m, overlay_len);
+
+out:
+    return 0;
+}
+
+static unsigned int
+dpdk_pgso_size(struct vr_packet *pkt)
+{
+    /* TODO: not implemented */
+    return 0;
+}
+
+static void
+dpdk_add_mpls(struct vrouter *router, unsigned mpls_label)
+{
+    int ret, i;
+    struct vr_interface *eth_vif;
+
+    for (i = 0; i < router->vr_max_interfaces; i++) {
+        eth_vif = __vrouter_get_interface(router, i);
+        if (eth_vif && (eth_vif->vif_type == VIF_TYPE_PHYSICAL)
+            && (eth_vif->vif_flags & VIF_FLAG_FILTERING_OFFLOAD)) {
+            RTE_LOG(INFO, VROUTER, "Enabling hardware acceleration on vif %u for MPLS %u\n",
+                (unsigned)eth_vif->vif_idx, mpls_label);
+            if (!eth_vif->vif_ip) {
+                RTE_LOG(ERR, VROUTER, "\terror accelerating MPLS %u: no IP address set\n",
+                    mpls_label);
+                continue;
+            }
+            ret = vr_dpdk_lcore_mpls_schedule(eth_vif, eth_vif->vif_ip, mpls_label);
+            if (ret != 0)
+                RTE_LOG(INFO, VROUTER, "\terror accelerating MPLS %u: %s (%d)\n",
+                    mpls_label, rte_strerror(-ret), -ret);
+        }
+    }
+
+}
+
+static void
+dpdk_del_mpls(struct vrouter *router, unsigned mpls_label)
+{
+    /* TODO: not implemented */
+}
+
+static int
+dpdk_pkt_may_pull(struct vr_packet *pkt, unsigned int len)
+{
+    struct rte_mbuf *mbuf = vr_dpdk_pkt_to_mbuf(pkt);
+
+    if (len > rte_pktmbuf_data_len(mbuf))
+        return -1;
+
+    vr_dpdk_mbuf_reset(pkt);
+    return 0;
+}
+
+
+struct host_os dpdk_host = {
+    .hos_printf                     =    dpdk_printf,
+    .hos_malloc                     =    dpdk_malloc,
+    .hos_zalloc                     =    dpdk_zalloc,
+    .hos_free                       =    dpdk_free,
+    .hos_vtop                       =    dpdk_vtop, /* not used */
+    .hos_page_alloc                 =    dpdk_page_alloc,
+    .hos_page_free                  =    dpdk_page_free,
+
+    .hos_palloc                     =    dpdk_palloc,
+    .hos_palloc_head                =    dpdk_palloc_head, /* not implemented */
+    .hos_pexpand_head               =    dpdk_pexpand_head, /* not implemented */
+    .hos_pfree                      =    dpdk_pfree,
+    .hos_preset                     =    dpdk_preset,
+    .hos_pclone                     =    dpdk_pclone,
+    .hos_pcopy                      =    dpdk_pcopy,
+    .hos_pfrag_len                  =    dpdk_pfrag_len,
+    .hos_phead_len                  =    dpdk_phead_len,
+    .hos_pset_data                  =    dpdk_pset_data,
+    .hos_pgso_size                  =    dpdk_pgso_size, /* not implemented, returns 0 */
+
+    .hos_get_cpu                    =    dpdk_get_cpu,
+    .hos_schedule_work              =    dpdk_schedule_work,
+    .hos_delay_op                   =    dpdk_delay_op, /* do nothing */
+    .hos_defer                      =    dpdk_defer, /* for mirroring? */
+    .hos_get_defer_data             =    dpdk_get_defer_data, /* for mirroring? */
+    .hos_put_defer_data             =    dpdk_put_defer_data, /* for mirroring? */
+    .hos_get_time                   =    dpdk_get_time,
+    .hos_get_mono_time              =    dpdk_get_mono_time,
+    .hos_create_timer               =    dpdk_create_timer,
+    .hos_delete_timer               =    dpdk_delete_timer,
+
+    .hos_network_header             =    dpdk_network_header, /* for chains? */
+    .hos_inner_network_header       =    dpdk_inner_network_header, /* not used? */
+    .hos_data_at_offset             =    dpdk_data_at_offset, /* for chains? */
+    .hos_pheader_pointer            =    dpdk_pheader_pointer,
+    .hos_pull_inner_headers         =    NULL,  /* not necessary */
+    .hos_pcow                       =    dpdk_pcow,
+    .hos_pull_inner_headers_fast    =    NULL,  /* not necessary */
+#if VR_DPDK_USE_MPLS_UDP_ECMP
+    .hos_get_udp_src_port           =    dpdk_get_udp_src_port,
+#endif
+    .hos_pkt_from_vm_tcp_mss_adj    =    dpdk_pkt_from_vm_tcp_mss_adj,
+    .hos_pkt_may_pull               =    dpdk_pkt_may_pull,
+
+    .hos_add_mpls                   =    dpdk_add_mpls,
+    .hos_del_mpls                   =    dpdk_del_mpls, /* not implemented */
+};
+
+struct host_os *
+vrouter_get_host(void)
+{
+    return &dpdk_host;
+}
+
+/* Remove xconnect callback */
+void
+vhost_remove_xconnect(void)
+{
+    int i;
+    struct vr_interface *vif;
+
+    for (i = 0; i < VR_MAX_INTERFACES; i++) {
+        vif = vr_dpdk.vhosts[i];
+        if (vif != NULL) {
+            vif_remove_xconnect(vif);
+            if (vif->vif_bridge != NULL)
+                vif_remove_xconnect(vif->vif_bridge);
+        }
+    }
+}
+
+/* Implementation of the Linux kernel function */
+void
+get_random_bytes(void *buf, int nbytes)
+{
+    int i;
+
+    if (nbytes == sizeof(uint32_t)) {
+        *(uint32_t *)buf = (uint32_t)rte_rand();
+    } else if (nbytes == sizeof(uint64_t)) {
+        *(uint64_t *)buf = rte_rand();
+    } else {
+        for (i = 0; i < nbytes; i++) {
+            *((uint8_t *)buf + i) = (uint8_t)rte_rand();
+        }
+    }
+}
+
+uint32_t
+jhash(void *key, uint32_t length, uint32_t initval)
+{
+    return rte_jhash(key, length, initval);
+}
+
+
+
+/* Convert internal packet fields
+ * Based on linux_get_packet()
+ */
+struct vr_packet *
+vr_dpdk_packet_get(struct rte_mbuf *m, struct vr_interface *vif)
+{
+    struct vr_packet *pkt = vr_dpdk_mbuf_to_pkt(m);
+    pkt->vp_cpu = vr_get_cpu();
+    /* vp_head is set in vr_dpdk_pktmbuf_init() */
+
+    pkt->vp_tail = rte_pktmbuf_headroom(m) + rte_pktmbuf_data_len(m);
+    pkt->vp_data = rte_pktmbuf_headroom(m);
+    /* vp_end is set in vr_dpdk_pktmbuf_init() */
+
+    pkt->vp_len = rte_pktmbuf_data_len(m);
+    pkt->vp_if = vif;
+    pkt->vp_network_h = pkt->vp_inner_network_h = 0;
+    pkt->vp_nh = NULL;
+    pkt->vp_flags = 0;
+    if (likely(m->ol_flags & PKT_TX_IP_CKSUM))
+        pkt->vp_flags |= VP_FLAG_CSUM_PARTIAL;
+
+    pkt->vp_ttl = 64;
+    pkt->vp_type = VP_TYPE_NULL;
+
+    return pkt;
+}
+
+/* Exit vRouter */
+void
+vr_dpdk_host_exit(void)
+{
+    vr_sandesh_exit();
+    vrouter_exit(false);
+
+    return;
+}
+
+/* Init vRouter */
+int
+vr_dpdk_host_init(void)
+{
+    int ret;
+
+    if (vr_host_inited)
+        return 0;
+
+    if (!vrouter_host) {
+        vrouter_host = vrouter_get_host();
+        if (vr_dpdk_flow_init()) {
+            return -1;
+        }
+    }
+
+    ret = vrouter_init();
+    if (ret)
+        return ret;
+
+    ret = vr_sandesh_init();
+    if (ret)
+        goto init_fail;
+
+    vr_host_inited = true;
+
+    return 0;
+
+init_fail:
+    vr_dpdk_host_exit();
+    return ret;
+}
+

--- a/dpdk/vr_dpdk_host.c
+++ b/dpdk/vr_dpdk_host.c
@@ -1162,3 +1162,23 @@ init_fail:
     return ret;
 }
 
+/* Retry socket connection */
+int
+vr_dpdk_retry_connect(int sockfd, const struct sockaddr *addr,
+                        socklen_t alen)
+{
+    int nsec;
+
+    for (nsec = 1; nsec < VR_DPDK_RETRY_CONNECT_SECS; nsec <<= 1) {
+        if (connect(sockfd, addr, alen) == 0)
+            return 0;
+
+        if (nsec < VR_DPDK_RETRY_CONNECT_SECS/2) {
+            sleep(nsec);
+            RTE_LOG(INFO, VROUTER, "Retrying connection for socket %d...\n",
+                    sockfd);
+        }
+    }
+
+    return -1;
+}

--- a/dpdk/vr_dpdk_interface.c
+++ b/dpdk/vr_dpdk_interface.c
@@ -1,0 +1,899 @@
+/*
+ * Copyright (C) 2014 Semihalf.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation version 2.
+ *
+ * This program is distributed "as is" WITHOUT ANY WARRANTY of any
+ * kind, whether express or implied; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * vr_dpdk_interface.c -- vRouter interface callbacks
+ *
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <net/if.h>
+#include <linux/vhost.h>
+
+#include "vr_queue.h"
+#include "vr_dpdk.h"
+#include "vr_dpdk_usocket.h"
+#include "vr_dpdk_virtio.h"
+#include "vr_dpdk_netlink.h"
+
+#include <rte_errno.h>
+
+/*
+ * dpdk_virtual_if_add - add a virtual (virtio) interface to vrouter.
+ * Returns 0 on success, < 0 otherwise.
+ */
+static int
+dpdk_virtual_if_add(struct vr_interface *vif)
+{
+    int ret;
+    unsigned int nrxqs, ntxqs;
+
+    RTE_LOG(INFO, VROUTER, "Adding vif %u virtual device %s\n",
+                vif->vif_idx, vif->vif_name);
+
+    nrxqs = vr_dpdk_virtio_nrxqs(vif);
+    ntxqs = vr_dpdk_virtio_ntxqs(vif);
+
+    ret = vr_dpdk_lcore_if_schedule(vif, vr_dpdk_lcore_least_used_get(),
+               nrxqs, &vr_dpdk_virtio_rx_queue_init,
+               ntxqs, &vr_dpdk_virtio_tx_queue_init);
+    if (ret) {
+        return ret;
+    }
+
+    /*
+     * When something goes wrong, vr_netlink_uvhost_vif_add() returns
+     * non-zero value. Then we return this value here. It is handled by
+     * dp-core and dpdk_virtual_if_del() is called, so there is no need
+     * to do it manually here.
+     *
+     * Check dp-core/vf_interface.c:eth_drv_add() for reference.
+     */
+    return vr_netlink_uvhost_vif_add(vif->vif_name, vif->vif_idx,
+                                    nrxqs, ntxqs);
+}
+
+/*
+ * dpdk_virtual_if_del - deletes a virtual (virtio) interface from vrouter.
+ * Returns 0 on success, -1 otherwise.
+ */
+static int
+dpdk_virtual_if_del(struct vr_interface *vif)
+{
+    int ret;
+
+    RTE_LOG(INFO, VROUTER, "Deleting vif %u virtual device\n",
+                vif->vif_idx);
+
+    ret = vr_netlink_uvhost_vif_del(vif->vif_idx);
+
+    vr_dpdk_lcore_if_unschedule(vif);
+
+    /*
+     * TODO - User space vhost thread need to ack the deletion of the vif.
+     */
+
+    return ret;
+}
+
+static inline void
+dpdk_dbdf_to_pci(unsigned int dbdf,
+        struct rte_pci_addr *address)
+{
+    address->domain = (dbdf >> 16);
+    address->bus = (dbdf >> 8) & 0xff;
+    address->devid = (dbdf & 0xf8);
+    address->function = (dbdf & 0x7);
+
+    return;
+}
+
+static inline unsigned
+dpdk_pci_to_dbdf(struct rte_pci_addr *address)
+{
+    return address->domain << 16
+        | address->bus << 8
+        | address->devid
+        | address->function;
+}
+
+/* mirrors the function used in bonding */
+static inline uint8_t
+dpdk_find_port_id_by_pci_addr(struct rte_pci_addr *addr)
+{
+    uint8_t i;
+    struct rte_pci_addr *eth_pci_addr;
+
+    for (i = 0; i < rte_eth_dev_count(); i++) {
+        if (rte_eth_devices[i].pci_dev == NULL)
+            continue;
+
+        eth_pci_addr = &(rte_eth_devices[i].pci_dev->addr);
+        if (addr->bus == eth_pci_addr->bus &&
+            addr->devid == eth_pci_addr->devid &&
+            addr->domain == eth_pci_addr->domain &&
+            addr->function == eth_pci_addr->function) {
+            return i;
+        }
+    }
+
+    return VR_DPDK_INVALID_PORT_ID;
+}
+static inline void
+dpdk_find_pci_addr_by_port(struct rte_pci_addr *addr, uint8_t port_id)
+{
+    rte_memcpy(addr, &rte_eth_devices[port_id].pci_dev->addr, sizeof(struct rte_pci_addr));
+}
+
+int
+dpdk_vif_attach_ethdev(struct vr_interface *vif,
+        struct vr_dpdk_ethdev *ethdev)
+{
+    int ret = 0;
+    struct ether_addr mac_addr;
+    struct rte_eth_dev_info dev_info;
+
+    vif->vif_os = (void *)ethdev;
+
+    rte_eth_dev_info_get(ethdev->ethdev_port_id, &dev_info);
+    if (dev_info.tx_offload_capa & DEV_TX_OFFLOAD_IPV4_CKSUM) {
+        vif->vif_flags |= VIF_FLAG_TX_CSUM_OFFLOAD;
+    } else {
+        vif->vif_flags &= ~VIF_FLAG_TX_CSUM_OFFLOAD;
+    }
+
+    memset(&mac_addr, 0, sizeof(mac_addr));
+    /*
+     * do not want to overwrite what agent had sent. set only if
+     * the address has null
+     */
+    if (!memcmp(vif->vif_mac, mac_addr.addr_bytes, ETHER_ADDR_LEN)) {
+        rte_eth_macaddr_get(ethdev->ethdev_port_id, &mac_addr);
+        memcpy(vif->vif_mac, mac_addr.addr_bytes, ETHER_ADDR_LEN);
+    }
+
+    return ret;
+}
+
+/* Add fabric interface */
+static int
+dpdk_fabric_if_add(struct vr_interface *vif)
+{
+    int ret;
+    uint8_t port_id;
+    struct rte_pci_addr pci_address;
+    struct vr_dpdk_ethdev *ethdev;
+    struct ether_addr mac_addr;
+
+    memset(&pci_address, 0, sizeof(pci_address));
+    if (vif->vif_flags & VIF_FLAG_PMD) {
+        if (vif->vif_os_idx >= rte_eth_dev_count()) {
+            RTE_LOG(ERR, VROUTER, "Invalid PMD device index %u"
+                    " (must be less than %u)\n",
+                    vif->vif_os_idx, (unsigned)rte_eth_dev_count());
+            return -ENOENT;
+        }
+
+        port_id = vif->vif_os_idx;
+        /* TODO: does not work for host interfaces
+        dpdk_find_pci_addr_by_port(&pci_address, port_id);
+        vif->vif_os_idx = dpdk_pci_to_dbdf(&pci_address);
+        */
+    } else {
+        dpdk_dbdf_to_pci(vif->vif_os_idx, &pci_address);
+        port_id = dpdk_find_port_id_by_pci_addr(&pci_address);
+        if (port_id == VR_DPDK_INVALID_PORT_ID) {
+            RTE_LOG(ERR, VROUTER, "Invalid PCI address %d:%d:%d:%d\n",
+                    pci_address.domain, pci_address.bus,
+                    pci_address.devid, pci_address.function);
+            return -ENOENT;
+        }
+    }
+
+    /* Please don't remove since we need it to debug. Thanks! */
+    memset(&mac_addr, 0, sizeof(mac_addr));
+    rte_eth_macaddr_get(port_id, &mac_addr);
+    RTE_LOG(INFO, VROUTER, "Adding vif %u eth device %" PRIu8 " PCI %d:%d.%d"
+        " MAC " MAC_FORMAT "\n",
+        vif->vif_idx, port_id, pci_address.bus, pci_address.devid, pci_address.function,
+        MAC_VALUE(mac_addr.addr_bytes));
+
+    ethdev = &vr_dpdk.ethdevs[port_id];
+    if (ethdev->ethdev_ptr != NULL) {
+        RTE_LOG(ERR, VROUTER, "\terror adding eth dev %s: already added\n",
+                vif->vif_name);
+        return -EEXIST;
+    }
+    ethdev->ethdev_port_id = port_id;
+
+    /* init eth device */
+    ret = vr_dpdk_ethdev_init(ethdev);
+    if (ret != 0)
+        return ret;
+
+    ret = dpdk_vif_attach_ethdev(vif, ethdev);
+    if (ret)
+        return ret;
+
+    ret = rte_eth_dev_start(port_id);
+    if (ret < 0) {
+        RTE_LOG(ERR, VROUTER, "\terror starting eth device %" PRIu8
+                ": %s (%d)\n", port_id, rte_strerror(-ret), -ret);
+        return ret;
+    }
+
+    ret = vr_dpdk_ethdev_rss_init(ethdev);
+    if (ret < 0)
+        return ret;
+
+    /* we need to init Flow Director after the device has started */
+#if VR_DPDK_USE_HW_FILTERING
+    /* init hardware filtering */
+    ret = vr_dpdk_ethdev_filtering_init(vif, ethdev);
+    if (ret < 0)
+        return ret;
+#endif
+
+    /* schedule RX/TX queues */
+    return vr_dpdk_lcore_if_schedule(vif, vr_dpdk_lcore_least_used_get(),
+        ethdev->ethdev_nb_rss_queues, &vr_dpdk_ethdev_rx_queue_init,
+        ethdev->ethdev_nb_tx_queues, &vr_dpdk_ethdev_tx_queue_init);
+}
+
+/* Delete fabric interface */
+static int
+dpdk_fabric_if_del(struct vr_interface *vif)
+{
+    uint8_t port_id;
+
+    RTE_LOG(INFO, VROUTER, "Deleting vif %u\n", vif->vif_idx);
+
+    /*
+     * If dpdk_fabric_if_add() failed before dpdk_vif_attach_ethdev,
+     * then vif->vif_os will be NULL.
+     */
+    if (vif->vif_os == NULL) {
+        RTE_LOG(ERR, VROUTER, "\terror deleting eth dev %s: already removed\n",
+                vif->vif_name);
+        return -EEXIST;
+    }
+
+    port_id = (((struct vr_dpdk_ethdev *)(vif->vif_os))->ethdev_port_id);
+
+    /* unschedule RX/TX queues */
+    vr_dpdk_lcore_if_unschedule(vif);
+
+    rte_eth_dev_stop(port_id);
+
+    /* release eth device */
+    return vr_dpdk_ethdev_release(vif->vif_os);
+}
+
+/* Add vhost interface */
+static int
+dpdk_vhost_if_add(struct vr_interface *vif)
+{
+    uint8_t port_id;
+    int ret;
+    struct ether_addr mac_addr;
+    struct rte_pci_addr pci_address;
+
+    if (vif->vif_flags & VIF_FLAG_PMD) {
+        port_id = vif->vif_os_idx;
+    }
+    else {
+        memset(&pci_address, 0, sizeof(pci_address));
+        dpdk_dbdf_to_pci(vif->vif_os_idx, &pci_address);
+        port_id = dpdk_find_port_id_by_pci_addr(&pci_address);
+    }
+
+    /* get interface MAC address */
+    memset(&mac_addr, 0, sizeof(mac_addr));
+    rte_eth_macaddr_get(port_id, &mac_addr);
+
+    RTE_LOG(INFO, VROUTER, "Adding vif %u KNI device %s at eth device %" PRIu8
+                " MAC " MAC_FORMAT "\n",
+                vif->vif_idx, vif->vif_name, port_id, MAC_VALUE(mac_addr.addr_bytes));
+
+    /* check if KNI is already added */
+    if (vr_dpdk.knis[vif->vif_idx] != NULL) {
+        RTE_LOG(ERR, VROUTER, "\terror adding KNI device %s: already exist\n",
+                vif->vif_name);
+        return -EEXIST;
+    }
+
+    /* init KNI */
+    ret = vr_dpdk_knidev_init(vif);
+    if (ret != 0)
+        return ret;
+
+    /* add interface to the table of KNIs */
+    vr_dpdk.knis[vif->vif_idx] = vif->vif_os;
+
+    /* add interface to the table of vHosts */
+    vr_dpdk.vhosts[vif->vif_idx] = vrouter_get_interface(vif->vif_rid, vif->vif_idx);
+
+    return vr_dpdk_lcore_if_schedule(vif, vr_dpdk_lcore_least_used_get(),
+            1, &vr_dpdk_kni_rx_queue_init,
+            1, &vr_dpdk_kni_tx_queue_init);
+}
+
+/* Delete vhost interface */
+static int
+dpdk_vhost_if_del(struct vr_interface *vif)
+{
+    RTE_LOG(INFO, VROUTER, "Deleting vif %u KNI device %s\n",
+                vif->vif_idx, vif->vif_name);
+
+    /* check if KNI exists */
+    if (vr_dpdk.knis[vif->vif_idx] == NULL) {
+        RTE_LOG(ERR, VROUTER, "\terror deleting KNI device %u: "
+                    "device does not exist\n", vif->vif_idx);
+        return -EEXIST;
+    }
+
+    vr_dpdk_lcore_if_unschedule(vif);
+
+    /* del the interface from the table of vHosts */
+    vr_dpdk.vhosts[vif->vif_idx] = NULL;
+
+    /* del the interface from the table of KNIs */
+    vr_dpdk.knis[vif->vif_idx] = NULL;
+
+    /* release KNI */
+    return vr_dpdk_knidev_release(vif);
+}
+
+/* Start interface monitoring */
+static void
+dpdk_monitoring_start(struct vr_interface *monitored_vif,
+    struct vr_interface *monitoring_vif)
+{
+    uint8_t port_id;
+
+    /* set monitoring redirection */
+    vr_dpdk.monitorings[monitored_vif->vif_idx] = monitoring_vif->vif_idx;
+
+    /* set vif flag */
+    rte_wmb();
+    monitored_vif->vif_flags |= VIF_FLAG_MONITORED;
+
+    if(vif_is_fabric(monitored_vif)) {
+        port_id = (((struct vr_dpdk_ethdev *)(monitored_vif->vif_os))->ethdev_port_id);
+        rte_eth_promiscuous_enable(port_id);
+    }
+}
+
+/* Stop interface monitoring */
+static void
+dpdk_monitoring_stop(struct vr_interface *monitored_vif,
+    struct vr_interface *monitoring_vif)
+{
+    uint8_t port_id;
+
+    /* check if the monitored vif was reused */
+    if (vr_dpdk.monitorings[monitored_vif->vif_idx] != monitoring_vif->vif_idx)
+        return;
+
+    /* clear vif flag */
+    monitored_vif->vif_flags &= ~((unsigned int)VIF_FLAG_MONITORED);
+    rte_wmb();
+
+    /* clear monitoring redirection */
+    vr_dpdk.monitorings[monitored_vif->vif_idx] = VR_MAX_INTERFACES;
+
+    if(vif_is_fabric(monitored_vif)) {
+        port_id = (((struct vr_dpdk_ethdev *)(monitored_vif->vif_os))->ethdev_port_id);
+        rte_eth_promiscuous_disable(port_id);
+    }
+}
+
+/* Add monitoring interface */
+static int
+dpdk_monitoring_if_add(struct vr_interface *vif)
+{
+    int ret;
+    unsigned short monitored_vif_id = vif->vif_os_idx;
+    struct vr_interface *monitored_vif;
+    struct vrouter *router = vrouter_get(vif->vif_rid);
+
+    RTE_LOG(INFO, VROUTER, "Adding monitoring vif %u KNI device %s"
+                " to monitor vif %u\n",
+                vif->vif_idx, vif->vif_name, monitored_vif_id);
+
+    /* Check if vif exist.
+     * We don't need vif reference in order to monitor it.
+     * We use the VIF_FLAG_MONITORED to copy in/out packet to the
+     * monitoring interface. If the monitored vif get deleted, we simply
+     * get no more packets.
+     */
+    monitored_vif = __vrouter_get_interface(router, monitored_vif_id);
+    if (!monitored_vif) {
+        RTE_LOG(ERR, VROUTER, "\terror getting vif to monitor: vif %u does not exist\n",
+                monitored_vif_id);
+        return -EINVAL;
+    }
+
+    /* check if KNI is already added */
+    if (vr_dpdk.knis[vif->vif_idx] != NULL) {
+        RTE_LOG(ERR, VROUTER, "\terror adding monitoring device %s: "
+                "vif %d KNI device already exist\n",
+                vif->vif_name, vif->vif_idx);
+        return -EEXIST;
+    }
+
+    /* init KNI */
+    ret = vr_dpdk_knidev_init(vif);
+    if (ret != 0)
+        return ret;
+
+    /* add interface to the table of KNIs */
+    vr_dpdk.knis[vif->vif_idx] = vif->vif_os;
+
+    /* write-only interface */
+    ret = vr_dpdk_lcore_if_schedule(vif, vr_dpdk_lcore_least_used_get(),
+            0, NULL,
+            1, &vr_dpdk_kni_tx_queue_init);
+    if (ret != 0)
+        return ret;
+
+    /* start monitoring */
+    dpdk_monitoring_start(monitored_vif, vif);
+
+    return 0;
+}
+
+/* Delete monitoring interface */
+static int
+dpdk_monitoring_if_del(struct vr_interface *vif)
+{
+    unsigned short monitored_vif_id = vif->vif_os_idx;
+    struct vr_interface *monitored_vif;
+
+    RTE_LOG(INFO, VROUTER, "Deleting monitoring vif %u KNI device"
+                " to monitor vif %u\n",
+                vif->vif_idx, monitored_vif_id);
+
+    /* check if vif exist */
+    monitored_vif = __vrouter_get_interface(vrouter_get(vif->vif_rid),
+                                                    monitored_vif_id);
+    if (!monitored_vif) {
+        RTE_LOG(ERR, VROUTER, "\terror getting vif to monitor: vif %u does not exist\n",
+                monitored_vif_id);
+    } else {
+        /* stop monitoring */
+        dpdk_monitoring_stop(monitored_vif, vif);
+    }
+
+    vr_dpdk_lcore_if_unschedule(vif);
+
+    /* check if KNI is added */
+    if (vr_dpdk.knis[vif->vif_idx] == NULL) {
+        RTE_LOG(ERR, VROUTER, "\terror deleting monitoring device: "
+                "vif %d KNI device does not exist\n",
+                vif->vif_idx);
+        return -EEXIST;
+    }
+
+    /* del the interface from the table of KNIs */
+    vr_dpdk.knis[vif->vif_idx] = NULL;
+
+    /* release KNI */
+    return vr_dpdk_knidev_release(vif);
+}
+
+/* Add agent interface */
+static int
+dpdk_agent_if_add(struct vr_interface *vif)
+{
+    int ret;
+
+    RTE_LOG(INFO, VROUTER, "Adding vif %u packet device %s\n",
+                vif->vif_idx, vif->vif_name);
+
+    /* check if packet device is already added */
+    if (vr_dpdk.packet_ring != NULL) {
+        RTE_LOG(ERR, VROUTER, "\terror adding packet device %s: already exist\n",
+            vif->vif_name);
+        return -EEXIST;
+    }
+
+    /* init packet device */
+    ret = dpdk_packet_socket_init();
+    if (ret)
+        return ret;
+
+    vr_usocket_attach_vif(vr_dpdk.packet_transport, vif);
+
+    /* schedule packet device with no hardware queues */
+    return vr_dpdk_lcore_if_schedule(vif, vr_dpdk.packet_lcore_id, 0, NULL, 0, NULL);
+}
+
+/* Delete agent interface */
+static int
+dpdk_agent_if_del(struct vr_interface *vif)
+{
+    RTE_LOG(INFO, VROUTER, "Deleting vif %u packet device\n",
+                vif->vif_idx);
+
+    dpdk_packet_socket_close();
+
+    return 0;
+}
+
+extern void vhost_remove_xconnect(void);
+
+/* vRouter callback */
+static int
+dpdk_if_add(struct vr_interface *vif)
+{
+    if (vif_is_fabric(vif)) {
+        return dpdk_fabric_if_add(vif);
+    } else if (vif_is_virtual(vif)) {
+        return dpdk_virtual_if_add(vif);
+    } else if (vif_is_vhost(vif)) {
+        return dpdk_vhost_if_add(vif);
+    } else if (vif->vif_type == VIF_TYPE_AGENT) {
+        if (vif->vif_transport == VIF_TRANSPORT_SOCKET)
+            return dpdk_agent_if_add(vif);
+
+        RTE_LOG(ERR, VROUTER, "Error adding vif %d packet device %s: "
+                "unsupported transport %d\n",
+                vif->vif_idx, vif->vif_name, vif->vif_transport);
+        return -EFAULT;
+    } else if (vif->vif_type == VIF_TYPE_MONITORING) {
+        return dpdk_monitoring_if_add(vif);
+    }
+
+    RTE_LOG(ERR, VROUTER, "Error adding vif %d (%s): unsupported interface type %d\n",
+            vif->vif_idx, vif->vif_name, vif->vif_type);
+
+    return -EFAULT;
+}
+
+static int
+dpdk_if_del(struct vr_interface *vif)
+{
+    if (vif_is_fabric(vif)) {
+        return dpdk_fabric_if_del(vif);
+    } else if (vif_is_virtual(vif)) {
+        return dpdk_virtual_if_del(vif);
+    } else if (vif_is_vhost(vif)) {
+        return dpdk_vhost_if_del(vif);
+    } else if (vif->vif_type == VIF_TYPE_AGENT) {
+        if (vif->vif_transport == VIF_TRANSPORT_SOCKET)
+            return dpdk_agent_if_del(vif);
+    } else if (vif->vif_type == VIF_TYPE_MONITORING) {
+        return dpdk_monitoring_if_del(vif);
+    }
+
+    RTE_LOG(ERR, VROUTER, "Unsupported interface type %d index %d\n",
+            vif->vif_type, vif->vif_idx);
+
+    return -EFAULT;
+}
+
+/* vRouter callback */
+static int
+dpdk_if_del_tap(struct vr_interface *vif)
+{
+    /* TODO: we untap interfaces at if_del */
+    return 0;
+}
+
+
+/* vRouter callback */
+static int
+dpdk_if_add_tap(struct vr_interface *vif)
+{
+    /* TODO: we tap interfaces at if_add */
+    return 0;
+}
+
+static inline void
+dpdk_hw_checksum_at_offset(struct vr_packet *pkt, unsigned offset)
+{
+    struct rte_mbuf *m = vr_dpdk_pkt_to_mbuf(pkt);
+    struct vr_ip *iph = (struct vr_ip *)(pkt->vp_head + offset);
+    unsigned iph_len = iph->ip_hl * 4;
+    struct vr_tcp *tcph;
+    struct vr_udp *udph;
+
+    RTE_VERIFY(0 < offset);
+
+    /* calculate IP checksum */
+    m->ol_flags |= PKT_TX_IP_CKSUM;
+    /* Note: Intel NICs need the checksum set to zero
+     * and proper l2/l3 lens to be set.
+     */
+    iph->ip_csum = 0;
+    m->pkt.vlan_macip.f.l2_len = offset - rte_pktmbuf_headroom(m);
+    m->pkt.vlan_macip.f.l3_len = iph_len;
+
+    RTE_LOG(DEBUG, VROUTER, "%s: Inner offset: l2_len = %d, l3_len = %d\n", __func__,
+        (int)m->pkt.vlan_macip.f.l2_len,
+        (int)m->pkt.vlan_macip.f.l3_len);
+
+    /* calculate TCP/UDP checksum */
+    if (likely(iph->ip_proto == VR_IP_PROTO_UDP)) {
+        /* TODO: disable UDP checksuming */
+        udph = (struct vr_udp *)((char *)iph + iph_len);
+        udph->udp_csum = 0;
+/*
+        m->ol_flags |= PKT_TX_UDP_CKSUM;
+        udph->udp_csum = vr_ip_partial_csum(iph);
+*/
+    } else if (likely(iph->ip_proto == VR_IP_PROTO_TCP)) {
+        m->ol_flags |= PKT_TX_TCP_CKSUM;
+        tcph = (struct vr_tcp *)((char *)iph + iph_len);
+        tcph->tcp_csum = vr_ip_partial_csum(iph);
+    }
+}
+
+static inline void
+dpdk_sw_checksum_at_offset(struct vr_packet *pkt, unsigned offset)
+{
+    struct vr_ip *iph = (struct vr_ip *)pkt_data_at_offset(pkt, offset);
+    unsigned iph_len = iph->ip_hl * 4;
+    struct vr_udp *udph;
+
+    RTE_VERIFY(0 < offset);
+
+    /* calculate IP checksum */
+    iph->ip_csum = vr_ip_csum(iph);
+
+    /* TODO: TCP checksums */
+    if (iph->ip_proto == VR_IP_PROTO_UDP) {
+        udph = (struct vr_udp *)pkt_data_at_offset(pkt, offset + iph_len);
+        /* disable UDP checksum */
+        udph->udp_csum = 0;
+    }
+}
+
+static inline void
+dpdk_hw_checksum(struct vr_packet *pkt)
+{
+    /* if a tunnel */
+    if (VP_TYPE_IPOIP == pkt->vp_type) {
+        /* calculate outer checksum in soft */
+        /* TODO: vlan support */
+        dpdk_sw_checksum_at_offset(pkt,
+            pkt->vp_data + sizeof(struct ether_hdr));
+        /* calculate inner checksum in hardware */
+        dpdk_hw_checksum_at_offset(pkt,
+               pkt_get_inner_network_header_off(pkt));
+    } else {
+        /* normal IP packet */
+        /* TODO: vlan support */
+        dpdk_hw_checksum_at_offset(pkt,
+            pkt->vp_data + sizeof(struct ether_hdr));
+    }
+}
+
+
+static inline void
+dpdk_sw_checksum(struct vr_packet *pkt)
+{
+    /* if a tunnel */
+    if (VP_TYPE_IPOIP == pkt->vp_type) {
+        /* calculate outer checksum */
+        /* TODO: vlan support */
+        dpdk_sw_checksum_at_offset(pkt,
+            pkt->vp_data + sizeof(struct ether_hdr));
+        /* calculate inner checksum */
+        dpdk_sw_checksum_at_offset(pkt,
+               pkt_get_inner_network_header_off(pkt));
+    } else {
+        /* normal IP packet */
+        /* TODO: vlan support */
+        dpdk_sw_checksum_at_offset(pkt,
+            pkt->vp_data + sizeof(struct ether_hdr));
+    }
+}
+
+/* TX packet callback */
+static int
+dpdk_if_tx(struct vr_interface *vif, struct vr_packet *pkt)
+{
+    const unsigned lcore_id = rte_lcore_id();
+    struct vr_dpdk_lcore * const lcore = vr_dpdk.lcores[lcore_id];
+    struct rte_mbuf *m = vr_dpdk_pkt_to_mbuf(pkt);
+    unsigned vif_idx = vif->vif_idx;
+    struct vr_dpdk_queue *tx_queue = &lcore->lcore_tx_queues[vif_idx];
+    struct vr_dpdk_queue *monitoring_tx_queue;
+    struct vr_packet *p_clone;
+
+    RTE_LOG(DEBUG, VROUTER,"%s: TX packet to interface %s\n", __func__,
+        vif->vif_name);
+
+    /* reset mbuf data pointer and length */
+    m->pkt.data = pkt_data(pkt);
+    m->pkt.data_len = pkt_head_len(pkt);
+    /* TODO: use pkt_len instead? */
+    m->pkt.pkt_len = pkt_head_len(pkt);
+
+    if (unlikely(vif->vif_flags & VIF_FLAG_MONITORED)) {
+        monitoring_tx_queue = &lcore->lcore_tx_queues[vr_dpdk.monitorings[vif_idx]];
+        if (likely(monitoring_tx_queue && monitoring_tx_queue->txq_ops.f_tx)) {
+            p_clone = vr_pclone(pkt);
+            if (likely(p_clone != NULL))
+                monitoring_tx_queue->txq_ops.f_tx(monitoring_tx_queue->q_queue_h,
+                    vr_dpdk_pkt_to_mbuf(p_clone));
+        }
+    }
+
+    if (unlikely(vif->vif_type == VIF_TYPE_AGENT)) {
+        rte_ring_enqueue_burst(vr_dpdk.packet_ring, (void *)&m, 1);
+#ifdef VR_DPDK_TX_PKT_DUMP
+        rte_pktmbuf_dump(stdout, m, 0x60);
+#endif
+        return 0;
+    }
+
+    /* TODO: Checksums
+     * With DPDK pktmbufs we don't know if the checksum is incomplete,
+     * i.e. there is no direct equivalent of skb->ip_summed field.
+     *
+     * So we just rely on VP_FLAG_CSUM_PARTIAL flag here, assuming
+     * the flag is set when we need to calculate inner or outer packet
+     * checksum.
+     *
+     * This is not elegant and need to be addressed.
+     * See dpdk/app/test-pmd/csumonly.c for more checksum examples
+     */
+    if (unlikely(pkt->vp_flags & VP_FLAG_CSUM_PARTIAL)) {
+        /* if NIC supports checksum offload */
+        if (likely(vif->vif_flags & VIF_FLAG_TX_CSUM_OFFLOAD))
+            dpdk_hw_checksum(pkt);
+        else
+            dpdk_sw_checksum(pkt);
+    }
+    /* TODO: checksums */
+//     else if (likely(VP_TYPE_IPOIP == pkt->vp_type)) {
+        /* always calculate outer checksum for tunnels */
+        /* if NIC supports checksum offload */
+//        if (likely(vif->vif_flags & VIF_FLAG_TX_CSUM_OFFLOAD)) {
+            /* TODO: vlan support */
+//            dpdk_hw_checksum_at_offset(pkt,
+//                pkt->vp_data + sizeof(struct ether_hdr));
+//        } else {
+            /* TODO: vlan support */
+//            dpdk_sw_checksum_at_offset(pkt,
+//                pkt->vp_data + sizeof(struct ether_hdr));
+//        }
+//    }
+
+#ifdef VR_DPDK_TX_PKT_DUMP
+    rte_pktmbuf_dump(stdout, m, 0x60);
+#endif
+
+    if (likely(tx_queue->txq_ops.f_tx != NULL))
+        tx_queue->txq_ops.f_tx(tx_queue->q_queue_h, m);
+
+    return 0;
+}
+
+static int
+dpdk_if_rx(struct vr_interface *vif, struct vr_packet *pkt)
+{
+    const unsigned lcore_id = rte_lcore_id();
+    struct vr_dpdk_lcore * const lcore = vr_dpdk.lcores[lcore_id];
+    struct rte_mbuf *m = vr_dpdk_pkt_to_mbuf(pkt);
+    unsigned vif_idx = vif->vif_idx;
+    struct vr_dpdk_queue *tx_queue = &lcore->lcore_tx_queues[vif_idx];
+    struct vr_dpdk_queue *monitoring_tx_queue;
+    struct vr_packet *p_clone;
+
+    RTE_LOG(DEBUG, VROUTER,"%s: TX packet to interface %s\n", __func__,
+        vif->vif_name);
+
+    /* reset mbuf data pointer and length */
+    m->pkt.data = pkt_data(pkt);
+    m->pkt.data_len = pkt_head_len(pkt);
+    /* TODO: use pkt_len instead? */
+    m->pkt.pkt_len = pkt_head_len(pkt);
+
+    if (unlikely(vif->vif_flags & VIF_FLAG_MONITORED)) {
+        monitoring_tx_queue = &lcore->lcore_tx_queues[vr_dpdk.monitorings[vif_idx]];
+        if (likely(monitoring_tx_queue && monitoring_tx_queue->txq_ops.f_tx)) {
+            p_clone = vr_pclone(pkt);
+            if (likely(p_clone != NULL))
+                monitoring_tx_queue->txq_ops.f_tx(monitoring_tx_queue->q_queue_h,
+                    vr_dpdk_pkt_to_mbuf(p_clone));
+        }
+    }
+
+#ifdef VR_DPDK_TX_PKT_DUMP
+    rte_pktmbuf_dump(stdout, m, 0x60);
+#endif
+
+    if (likely(tx_queue->txq_ops.f_tx != NULL))
+        tx_queue->txq_ops.f_tx(tx_queue->q_queue_h, m);
+
+    return 0;
+}
+
+static int
+dpdk_if_get_settings(struct vr_interface *vif,
+        struct vr_interface_settings *settings)
+{
+    /* TODO: not implemented */
+    settings->vis_speed = 1000;
+    settings->vis_duplex = 1;
+    return 0;
+}
+
+static unsigned int
+dpdk_if_get_mtu(struct vr_interface *vif)
+{
+    uint8_t port_id;
+    uint16_t mtu;
+
+    if (vif->vif_type == VIF_TYPE_PHYSICAL) {
+        port_id = (((struct vr_dpdk_ethdev *)(vif->vif_os))->ethdev_port_id);
+        if (rte_eth_dev_get_mtu(port_id, &mtu) == 0)
+            return mtu;
+    }
+
+    return vif->vif_mtu;
+}
+
+static void
+dpdk_if_unlock(void)
+{
+    vr_dpdk_if_unlock();
+}
+
+static void
+dpdk_if_lock(void)
+{
+    vr_dpdk_if_lock();
+}
+
+static unsigned short
+dpdk_if_get_encap(struct vr_interface *vif)
+{
+    return VIF_ENCAP_TYPE_ETHER;
+}
+
+struct vr_host_interface_ops dpdk_interface_ops = {
+    .hif_lock           =    dpdk_if_lock,
+    .hif_unlock         =    dpdk_if_unlock,
+    .hif_add            =    dpdk_if_add,
+    .hif_del            =    dpdk_if_del,
+    .hif_add_tap        =    dpdk_if_add_tap,   /* not implemented */
+    .hif_del_tap        =    dpdk_if_del_tap,   /* not implemented */
+    .hif_tx             =    dpdk_if_tx,
+    .hif_rx             =    dpdk_if_rx,
+    .hif_get_settings   =    dpdk_if_get_settings, /* always returns speed 1000 duplex 1 */
+    .hif_get_mtu        =    dpdk_if_get_mtu,
+    .hif_get_encap      =    dpdk_if_get_encap, /* always returns VIF_ENCAP_TYPE_ETHER */
+};
+
+void
+vr_host_vif_init(struct vrouter *router)
+{
+    return;
+}
+
+struct vr_host_interface_ops *
+vr_host_interface_init(void)
+{
+    return &dpdk_interface_ops;
+}
+
+void
+vr_host_interface_exit(void)
+{
+    return;
+}

--- a/dpdk/vr_dpdk_interface.c
+++ b/dpdk/vr_dpdk_interface.c
@@ -746,6 +746,7 @@ dpdk_if_tx(struct vr_interface *vif, struct vr_packet *pkt)
 #endif
         rte_pktmbuf_dump(stdout, m, 0x60);
 #endif
+        vr_dpdk_packet_wakeup(lcore);
         return 0;
     }
 

--- a/dpdk/vr_dpdk_interface.c
+++ b/dpdk/vr_dpdk_interface.c
@@ -741,6 +741,9 @@ dpdk_if_tx(struct vr_interface *vif, struct vr_packet *pkt)
     if (unlikely(vif->vif_type == VIF_TYPE_AGENT)) {
         rte_ring_enqueue_burst(vr_dpdk.packet_ring, (void *)&m, 1);
 #ifdef VR_DPDK_TX_PKT_DUMP
+#ifdef VR_DPDK_PKT_DUMP_VIF_FILTER
+        if (VR_DPDK_PKT_DUMP_VIF_FILTER(vif))
+#endif
         rte_pktmbuf_dump(stdout, m, 0x60);
 #endif
         return 0;
@@ -780,6 +783,9 @@ dpdk_if_tx(struct vr_interface *vif, struct vr_packet *pkt)
 //    }
 
 #ifdef VR_DPDK_TX_PKT_DUMP
+#ifdef VR_DPDK_PKT_DUMP_VIF_FILTER
+    if (VR_DPDK_PKT_DUMP_VIF_FILTER(vif))
+#endif
     rte_pktmbuf_dump(stdout, m, 0x60);
 #endif
 
@@ -820,6 +826,9 @@ dpdk_if_rx(struct vr_interface *vif, struct vr_packet *pkt)
     }
 
 #ifdef VR_DPDK_TX_PKT_DUMP
+#ifdef VR_DPDK_PKT_DUMP_VIF_FILTER
+    if (VR_DPDK_PKT_DUMP_VIF_FILTER(vif))
+#endif
     rte_pktmbuf_dump(stdout, m, 0x60);
 #endif
 

--- a/dpdk/vr_dpdk_interface.c
+++ b/dpdk/vr_dpdk_interface.c
@@ -537,6 +537,9 @@ extern void vhost_remove_xconnect(void);
 static int
 dpdk_if_add(struct vr_interface *vif)
 {
+    if (vr_dpdk_is_stop_flag_set())
+        return -EINPROGRESS;
+
     if (vif_is_fabric(vif)) {
         return dpdk_fabric_if_add(vif);
     } else if (vif_is_virtual(vif)) {
@@ -564,6 +567,9 @@ dpdk_if_add(struct vr_interface *vif)
 static int
 dpdk_if_del(struct vr_interface *vif)
 {
+    if (vr_dpdk_is_stop_flag_set())
+        return -EINPROGRESS;
+
     if (vif_is_fabric(vif)) {
         return dpdk_fabric_if_del(vif);
     } else if (vif_is_virtual(vif)) {

--- a/dpdk/vr_dpdk_interface.c
+++ b/dpdk/vr_dpdk_interface.c
@@ -790,8 +790,15 @@ dpdk_if_tx(struct vr_interface *vif, struct vr_packet *pkt)
     rte_pktmbuf_dump(stdout, m, 0x60);
 #endif
 
-    if (likely(tx_queue->txq_ops.f_tx != NULL))
+    if (likely(tx_queue->txq_ops.f_tx != NULL)) {
         tx_queue->txq_ops.f_tx(tx_queue->q_queue_h, m);
+        if (lcore_id == vr_dpdk.packet_lcore_id)
+            tx_queue->txq_ops.f_flush(tx_queue->q_queue_h);
+    } else {
+        RTE_LOG(DEBUG, VROUTER,"%s: error TXing to interface %s: no queue for lcore %u\n",
+                __func__, vif->vif_name, lcore_id);
+        rte_pktmbuf_free(m);
+    }
 
     return 0;
 }
@@ -833,8 +840,15 @@ dpdk_if_rx(struct vr_interface *vif, struct vr_packet *pkt)
     rte_pktmbuf_dump(stdout, m, 0x60);
 #endif
 
-    if (likely(tx_queue->txq_ops.f_tx != NULL))
+    if (likely(tx_queue->txq_ops.f_tx != NULL)) {
         tx_queue->txq_ops.f_tx(tx_queue->q_queue_h, m);
+        if (lcore_id == vr_dpdk.packet_lcore_id)
+            tx_queue->txq_ops.f_flush(tx_queue->q_queue_h);
+    } else {
+        RTE_LOG(DEBUG, VROUTER,"%s: error TXing to interface %s: no queue for lcore %u\n",
+                __func__, vif->vif_name, lcore_id);
+        rte_pktmbuf_free(m);
+    }
 
     return 0;
 }

--- a/dpdk/vr_dpdk_knidev.c
+++ b/dpdk/vr_dpdk_knidev.c
@@ -1,0 +1,491 @@
+/*
+ * Copyright (C) 2014 Semihalf.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation version 2.
+ *
+ * This program is distributed "as is" WITHOUT ANY WARRANTY of any
+ * kind, whether express or implied; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * vr_dpdk_knidev.c -- DPDK KNI device
+ *
+ */
+#include <stdio.h>
+#include <unistd.h>
+
+#include <rte_malloc.h>
+
+#include "vr_dpdk.h"
+
+/*
+ * KNI Reader
+ */
+struct dpdk_knidev_reader {
+    struct rte_kni *kni;
+};
+
+struct dpdk_knidev_reader_params {
+    /* Pointer to preallocated KNI */
+    struct rte_kni *kni;
+};
+
+static void *
+dpdk_knidev_reader_create(void *params, int socket_id)
+{
+    struct dpdk_knidev_reader_params *conf =
+            (struct dpdk_knidev_reader_params *) params;
+    struct dpdk_knidev_reader *port;
+
+    /* Check input parameters */
+    if (conf == NULL) {
+        RTE_LOG(ERR, PORT, "%s: params is NULL\n", __func__);
+        return NULL;
+    }
+
+    /* Memory allocation */
+    port = rte_zmalloc_socket("PORT", sizeof(*port),
+            CACHE_LINE_SIZE, socket_id);
+    if (port == NULL) {
+        RTE_LOG(ERR, PORT, "%s: Failed to allocate port\n", __func__);
+        return NULL;
+    }
+
+    /* Initialization */
+    port->kni = conf->kni;
+
+    return port;
+}
+
+static int
+dpdk_knidev_reader_rx(void *port, struct rte_mbuf **pkts, uint32_t n_pkts)
+{
+    struct dpdk_knidev_reader *p =
+        (struct dpdk_knidev_reader *) port;
+
+    return rte_kni_rx_burst(p->kni, pkts, n_pkts);
+}
+
+static int
+dpdk_knidev_reader_free(void *port)
+{
+    if (port == NULL) {
+        RTE_LOG(ERR, PORT, "%s: port is NULL\n", __func__);
+        return -EINVAL;
+    }
+
+    rte_free(port);
+
+    return 0;
+}
+
+/*
+ * KNI Writer
+ */
+struct dpdk_knidev_writer {
+    struct rte_mbuf *tx_buf[2 * RTE_PORT_IN_BURST_SIZE_MAX];
+    uint32_t tx_burst_sz;
+    uint16_t tx_buf_count;
+    uint64_t bsz_mask;
+    struct rte_kni *kni;
+};
+
+struct dpdk_knidev_writer_params {
+    /* Pointer to preallocated KNI */
+    struct rte_kni *kni;
+    /* Recommended burst size */
+    uint32_t tx_burst_sz;
+};
+
+static void *
+dpdk_knidev_writer_create(void *params, int socket_id)
+{
+    struct dpdk_knidev_writer_params *conf =
+            (struct dpdk_knidev_writer_params *) params;
+    struct dpdk_knidev_writer *port;
+
+    /* Check input parameters */
+    if ((conf == NULL) ||
+        (conf->tx_burst_sz == 0) ||
+        (conf->tx_burst_sz > RTE_PORT_IN_BURST_SIZE_MAX) ||
+        (!rte_is_power_of_2(conf->tx_burst_sz))) {
+        RTE_LOG(ERR, PORT, "%s: Invalid input parameters\n", __func__);
+        return NULL;
+    }
+
+    /* Memory allocation */
+    port = rte_zmalloc_socket("PORT", sizeof(*port),
+            CACHE_LINE_SIZE, socket_id);
+    if (port == NULL) {
+        RTE_LOG(ERR, PORT, "%s: Failed to allocate port\n", __func__);
+        return NULL;
+    }
+
+    /* Initialization */
+    port->kni = conf->kni;
+    port->tx_burst_sz = conf->tx_burst_sz;
+    port->tx_buf_count = 0;
+    port->bsz_mask = 1LLU << (conf->tx_burst_sz - 1);
+
+    return port;
+}
+
+static inline void
+send_burst(struct dpdk_knidev_writer *p)
+{
+    uint32_t nb_tx;
+
+    nb_tx = rte_kni_tx_burst(p->kni, p->tx_buf, p->tx_buf_count);
+
+    for ( ; nb_tx < p->tx_buf_count; nb_tx++)
+        rte_pktmbuf_free(p->tx_buf[nb_tx]);
+
+    p->tx_buf_count = 0;
+}
+
+static int
+dpdk_knidev_writer_tx(void *port, struct rte_mbuf *pkt)
+{
+    struct dpdk_knidev_writer *p = (struct dpdk_knidev_writer *) port;
+
+    p->tx_buf[p->tx_buf_count++] = pkt;
+    if (p->tx_buf_count >= p->tx_burst_sz)
+        send_burst(p);
+
+    return 0;
+}
+
+static int
+dpdk_knidev_writer_flush(void *port)
+{
+    struct dpdk_knidev_writer *p = (struct dpdk_knidev_writer *) port;
+
+    if (p->tx_buf_count > 0)
+        send_burst(p);
+
+    return 0;
+}
+
+static int
+dpdk_knidev_writer_free(void *port)
+{
+    if (port == NULL) {
+        RTE_LOG(ERR, PORT, "%s: Port is NULL\n", __func__);
+        return -EINVAL;
+    }
+
+    dpdk_knidev_writer_flush(port);
+    rte_free(port);
+
+    return 0;
+}
+
+/*
+ * Summary of KNI operations
+ */
+struct rte_port_in_ops dpdk_knidev_reader_ops = {
+    .f_create = dpdk_knidev_reader_create,
+    .f_free = dpdk_knidev_reader_free,
+    .f_rx = dpdk_knidev_reader_rx,
+};
+
+struct rte_port_out_ops dpdk_knidev_writer_ops = {
+    .f_create = dpdk_knidev_writer_create,
+    .f_free = dpdk_knidev_writer_free,
+    .f_tx = dpdk_knidev_writer_tx,
+    .f_tx_bulk = NULL, /* TODO: not implemented */
+    .f_flush = dpdk_knidev_writer_flush,
+};
+
+/* Release KNI RX queue */
+static void
+dpdk_kni_rx_queue_release(unsigned lcore_id, struct vr_interface *vif)
+{
+    struct vr_dpdk_lcore *lcore = vr_dpdk.lcores[lcore_id];
+    struct vr_dpdk_queue *rx_queue = &lcore->lcore_rx_queues[vif->vif_idx];
+    struct vr_dpdk_queue_params *rx_queue_params
+                        = &lcore->lcore_rx_queue_params[vif->vif_idx];
+
+    /* free the queue */
+    if (rx_queue->rxq_ops.f_free(rx_queue->q_queue_h)) {
+        RTE_LOG(ERR, VROUTER, "\terror freeing lcore %u KNI device RX queue\n",
+                    lcore_id);
+    }
+
+    /* reset the queue */
+    vrouter_put_interface(rx_queue->q_vif);
+    memset(rx_queue, 0, sizeof(*rx_queue));
+    memset(rx_queue_params, 0, sizeof(*rx_queue_params));
+}
+
+/* Init KNI RX queue */
+struct vr_dpdk_queue *
+vr_dpdk_kni_rx_queue_init(unsigned lcore_id, struct vr_interface *vif,
+    unsigned host_lcore_id)
+{
+    struct vr_dpdk_lcore *lcore = vr_dpdk.lcores[lcore_id];
+    const unsigned socket_id = rte_lcore_to_socket_id(lcore_id);
+    uint8_t port_id = 0;
+    unsigned vif_idx = vif->vif_idx;
+    struct vr_dpdk_queue *rx_queue = &lcore->lcore_rx_queues[vif_idx];
+    struct vr_dpdk_queue_params *rx_queue_params
+                    = &lcore->lcore_rx_queue_params[vif_idx];
+
+    if (vif->vif_type == VIF_TYPE_HOST) {
+        port_id = (((struct vr_dpdk_ethdev *)(vif->vif_bridge->vif_os))->
+                ethdev_port_id);
+    }
+
+    /* init queue */
+    rx_queue->rxq_ops = dpdk_knidev_reader_ops;
+    rx_queue->q_queue_h = NULL;
+    rx_queue->rxq_burst_size = VR_DPDK_KNI_RX_BURST_SZ;
+    rx_queue->q_vif = vrouter_get_interface(vif->vif_rid, vif_idx);
+
+    /* create the queue */
+    struct dpdk_knidev_reader_params reader_params = {
+        .kni = vif->vif_os,
+    };
+    rx_queue->q_queue_h = rx_queue->rxq_ops.f_create(&reader_params, socket_id);
+    if (rx_queue->q_queue_h == NULL) {
+        RTE_LOG(ERR, VROUTER, "\terror creating KNI device %s RX queue at eth device %"
+            PRIu8 "\n", vif->vif_name, port_id);
+        return NULL;
+    }
+
+    /* store queue params */
+    rx_queue_params->qp_release_op = &dpdk_kni_rx_queue_release;
+
+    return rx_queue;
+}
+
+/* Release KNI TX queue */
+static void
+dpdk_kni_tx_queue_release(unsigned lcore_id, struct vr_interface *vif)
+{
+    struct vr_dpdk_lcore *lcore = vr_dpdk.lcores[lcore_id];
+    struct vr_dpdk_queue *tx_queue = &lcore->lcore_tx_queues[vif->vif_idx];
+    struct vr_dpdk_queue_params *tx_queue_params
+                        = &lcore->lcore_tx_queue_params[vif->vif_idx];
+
+    tx_queue->txq_ops.f_tx = NULL;
+    rte_wmb();
+
+    /* flush and free the queue */
+    if (tx_queue->txq_ops.f_free(tx_queue->q_queue_h)) {
+        RTE_LOG(ERR, VROUTER, "\terror freeing lcore %u KNI device TX queue\n",
+                    lcore_id);
+    }
+
+    /* reset the queue */
+    vrouter_put_interface(tx_queue->q_vif);
+    memset(tx_queue, 0, sizeof(*tx_queue));
+    memset(tx_queue_params, 0, sizeof(*tx_queue_params));
+}
+
+/* Init KNI TX queue */
+struct vr_dpdk_queue *
+vr_dpdk_kni_tx_queue_init(unsigned lcore_id, struct vr_interface *vif,
+    unsigned host_lcore_id)
+{
+    struct vr_dpdk_lcore *lcore = vr_dpdk.lcores[lcore_id];
+    const unsigned socket_id = rte_lcore_to_socket_id(lcore_id);
+    uint8_t port_id = 0;
+    unsigned vif_idx = vif->vif_idx;
+    struct vr_dpdk_queue *tx_queue = &lcore->lcore_tx_queues[vif_idx];
+    struct vr_dpdk_queue_params *tx_queue_params
+                    = &lcore->lcore_tx_queue_params[vif_idx];
+
+    if (vif->vif_type == VIF_TYPE_HOST) {
+        port_id = (((struct vr_dpdk_ethdev *)(vif->vif_bridge->vif_os))->
+                ethdev_port_id);
+    }
+
+    /* init queue */
+    tx_queue->txq_ops = dpdk_knidev_writer_ops;
+    tx_queue->q_queue_h = NULL;
+    tx_queue->q_vif = vrouter_get_interface(vif->vif_rid, vif_idx);
+
+    /* create the queue */
+    struct dpdk_knidev_writer_params writer_params = {
+        .kni = vif->vif_os,
+        .tx_burst_sz = VR_DPDK_KNI_TX_BURST_SZ,
+    };
+    tx_queue->q_queue_h = tx_queue->txq_ops.f_create(&writer_params, socket_id);
+    if (tx_queue->q_queue_h == NULL) {
+        RTE_LOG(ERR, VROUTER, "\terror creating KNI device %s TX queue at eth device %"
+            PRIu8 "\n", vif->vif_name, port_id);
+        return NULL;
+    }
+
+    /* store queue params */
+    tx_queue_params->qp_release_op = &dpdk_kni_tx_queue_release;
+
+    return tx_queue;
+}
+
+/* Change KNI MTU size callback */
+static int
+dpdk_knidev_change_mtu(uint8_t port_id, unsigned new_mtu)
+{
+    struct vrouter *router = vrouter_get(0);
+    struct vr_interface *vif;
+    int i = 0;
+    uint8_t ethdev_port_id;
+    int ret = 0;
+
+    RTE_LOG(INFO, VROUTER, "Change MTU of eth device %" PRIu8 " to %u\n",
+                    port_id, new_mtu);
+    if (port_id >= rte_eth_dev_count()) {
+        RTE_LOG(ERR, VROUTER, "Invalid eth device %" PRIu8 "\n", port_id);
+        return -EINVAL;
+    }
+
+    ret =  rte_eth_dev_set_mtu(port_id, new_mtu);
+
+    if (ret < 0) {
+        RTE_LOG(ERR, VROUTER, "Change MTU of eth device %" PRIu8 " to %u"
+                        " failed (%d)\n", port_id, new_mtu, ret);
+    }
+    else { /* On success, inform vrouter about new MTU */
+        vr_dpdk_if_lock();
+        for (i = 0; i < router->vr_max_interfaces; i++) {
+            vif = __vrouter_get_interface(router, i);
+            if (vif && (vif->vif_type == VIF_TYPE_PHYSICAL)) {
+                ethdev_port_id = (((struct vr_dpdk_ethdev *)(vif->vif_os))->
+                            ethdev_port_id);
+                if (ethdev_port_id == port_id) {
+                    vif->vif_mtu = new_mtu;
+                    if (vif->vif_bridge)
+                        vif->vif_bridge->vif_mtu = new_mtu;
+                }
+            }
+        }
+        vr_dpdk_if_unlock();
+    }
+
+    return ret;
+}
+
+
+/* Configure KNI state callback */
+static int
+dpdk_knidev_config_network_if(uint8_t port_id, uint8_t if_up)
+{
+    int ret = 0;
+
+    RTE_LOG(INFO, VROUTER, "Configuring eth device %" PRIu8 " %s\n",
+                    port_id, if_up ? "UP" : "DOWN");
+    if (port_id >= rte_eth_dev_count() || port_id >= RTE_MAX_ETHPORTS) {
+        RTE_LOG(ERR, VROUTER, "Invalid eth device %" PRIu8 "\n", port_id);
+        return -EINVAL;
+    }
+
+    vr_dpdk_if_lock();
+    if (if_up)
+        ret = rte_eth_dev_start(port_id);
+    else
+        rte_eth_dev_stop(port_id);
+    vr_dpdk_if_unlock();
+
+    if (ret < 0) {
+        RTE_LOG(ERR, VROUTER, "Configuring eth device %" PRIu8 " UP"
+                    "failed (%d)", port_id, ret);
+    }
+
+    return ret;
+}
+
+/* Init KNI */
+int
+vr_dpdk_knidev_init(struct vr_interface *vif)
+{
+    uint8_t port_id;
+    struct vr_dpdk_ethdev *ethdev;
+    struct rte_eth_dev_info dev_info;
+    struct rte_kni_conf kni_conf;
+    struct rte_kni *kni;
+
+    if (vif->vif_type == VIF_TYPE_HOST) {
+        ethdev = (struct vr_dpdk_ethdev *)(vif->vif_bridge->vif_os);
+        /* TODO: in test scripts ethdev is null here */
+        if (ethdev)
+            port_id = ethdev->ethdev_port_id;
+        else
+            /* ...so we use os_idx instead */
+            port_id = vif->vif_os_idx;
+    } else if (vif->vif_type == VIF_TYPE_MONITORING) {
+            /*
+             * DPDK numerates all the detected Ethernet devices starting from 0.
+             * So we might get into an issue if we have no eth devices at all
+             * or we have few eth ports and don't what to use the first one.
+             */
+            port_id = 0; /* TODO: we always use DPDK port 0 */
+    } else {
+        RTE_LOG(ERR, VROUTER, "\tunknown KNI interface addition"
+                "type %d os index %d\n", vif->vif_type, vif->vif_os_idx);
+        return -EINVAL;
+    }
+
+    /* get eth device info */
+    memset(&dev_info, 0, sizeof(dev_info));
+    rte_eth_dev_info_get(port_id, &dev_info);
+
+    /* create KNI configuration */
+    memset(&kni_conf, 0, sizeof(kni_conf));
+    strncpy(kni_conf.name, (char *)vif->vif_name, sizeof(kni_conf.name) - 1);
+
+    kni_conf.addr = dev_info.pci_dev->addr;
+    kni_conf.id = dev_info.pci_dev->id;
+    kni_conf.group_id = port_id;
+    kni_conf.mbuf_size = VR_DPDK_MAX_PACKET_SZ;
+
+    /* KNI options */
+    struct rte_kni_ops kni_ops = {
+        .port_id = port_id,
+        .change_mtu = dpdk_knidev_change_mtu,
+        .config_network_if = dpdk_knidev_config_network_if,
+    };
+
+    /* allocate KNI device */
+    kni = rte_kni_alloc(vr_dpdk.rss_mempool, &kni_conf, &kni_ops);
+    if (kni == NULL) {
+        RTE_LOG(ERR, VROUTER, "\terror allocation KNI device %s at eth device %"
+                PRIu8 "\n", vif->vif_name, port_id);
+        return -ENOMEM;
+    }
+
+    /* store pointer to KNI for further use */
+    vif->vif_os = kni;
+
+    return 0;
+}
+
+/* Release KNI */
+int
+vr_dpdk_knidev_release(struct vr_interface *vif)
+{
+    struct rte_kni *kni = vif->vif_os;
+
+    vif->vif_os = NULL;
+    rte_wmb();
+    return rte_kni_release(kni);
+}
+
+/* Handle all KNIs attached */
+void
+vr_dpdk_knidev_all_handle(void)
+{
+    struct vrouter *router = vrouter_get(0);
+    int i;
+    struct vr_interface *vif;
+
+    for (i = 0; i < router->vr_max_interfaces; i++) {
+        vif = __vrouter_get_interface(router, i);
+        if (vif && (vif->vif_type == VIF_TYPE_HOST
+                    || vif->vif_type == VIF_TYPE_MONITORING))
+            rte_kni_handle_request((struct rte_kni *)vif->vif_os);
+    }
+}

--- a/dpdk/vr_dpdk_lcore.c
+++ b/dpdk/vr_dpdk_lcore.c
@@ -1,0 +1,788 @@
+/*
+ * Copyright (C) 2014 Semihalf.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation version 2.
+ *
+ * This program is distributed "as is" WITHOUT ANY WARRANTY of any
+ * kind, whether express or implied; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * vr_dpdk_lcore.c -- lcore support functions
+ *
+ */
+
+#include <sched.h>
+#include <rte_malloc.h>
+#include <urcu-qsbr.h>
+#include <linux/vhost.h>
+
+#include "vr_dpdk.h"
+#include "vr_dpdk_usocket.h"
+#include "vr_dpdk_virtio.h"
+
+/*
+ * vr_dpdk_phys_lcore_least_used_get - returns the least used lcore among the
+ * ones that handle TX for physical interfaces.
+ */
+unsigned int
+vr_dpdk_phys_lcore_least_used_get(void)
+{
+    unsigned lcore_id;
+    struct vr_dpdk_lcore *lcore;
+    unsigned least_used_id = RTE_MAX_LCORE;
+    uint16_t least_used_nb_queues = 2 * VR_MAX_INTERFACES;
+    unsigned int num_queues;
+
+    RTE_LCORE_FOREACH(lcore_id) {
+        lcore = vr_dpdk.lcores[lcore_id];
+        num_queues = lcore->lcore_nb_rx_queues + lcore->lcore_nb_rings_to_push;
+
+        /*
+         * Use <= instead of < below so that this function returns lcores
+         * from the last lcore while vr_dpdk_lcore_least_used_get returns
+         * lcores from the first. This will ensure that the lcores which
+         * process TX from VMs are different from the one which send packets
+         * out the wire (subject to number of cores).
+         */
+        if (num_queues <= least_used_nb_queues) {
+            least_used_nb_queues = num_queues;
+            least_used_id = lcore_id;
+        }
+    }
+
+    return least_used_id;
+}
+
+/* Returns the least used lcore or RTE_MAX_LCORE */
+unsigned
+vr_dpdk_lcore_least_used_get(void)
+{
+    unsigned lcore_id;
+    struct vr_dpdk_lcore *lcore;
+    unsigned least_used_id = RTE_MAX_LCORE;
+    uint16_t least_used_nb_queues = 2 * VR_MAX_INTERFACES;
+    unsigned int num_queues;
+
+    RTE_LCORE_FOREACH(lcore_id) {
+        if (lcore_id == vr_dpdk.packet_lcore_id)
+            continue;
+        lcore = vr_dpdk.lcores[lcore_id];
+
+        num_queues = lcore->lcore_nb_rx_queues +
+                      lcore->lcore_nb_rings_to_push;
+        if (num_queues < least_used_nb_queues) {
+            least_used_nb_queues = num_queues;
+            least_used_id = lcore_id;
+        }
+    }
+
+    return least_used_id;
+}
+
+/* Add a queue to a lcore
+ * The moment the function is called from the NetLink lcore ATM.
+ */
+void
+dpdk_lcore_queue_add(unsigned lcore_id, struct vr_dpdk_q_slist *q_head,
+                        struct vr_dpdk_queue *queue)
+{
+    unsigned vif_idx = queue->q_vif->vif_idx;
+    struct vr_dpdk_queue *prev_queue;
+    struct vr_dpdk_queue *cur_queue;
+    struct vr_dpdk_lcore *lcore = vr_dpdk.lcores[lcore_id];
+
+    /* write barrier */
+    rte_wmb();
+
+    /* add queue to the list */
+    if (SLIST_EMPTY(q_head)) {
+        /* insert first queue */
+        SLIST_INSERT_HEAD(q_head, queue, q_next);
+    } else {
+        /* sort TX queues by vif_idx to optimize CPU cache usage */
+        prev_queue = NULL;
+        SLIST_FOREACH(cur_queue, q_head, q_next) {
+            if (cur_queue->q_vif->vif_idx < vif_idx)
+                prev_queue = cur_queue;
+            else
+                break;
+        }
+        /* insert new queue */
+        if (prev_queue == NULL)
+            SLIST_INSERT_HEAD(q_head, queue, q_next);
+        else
+            SLIST_INSERT_AFTER(prev_queue, queue, q_next);
+    }
+
+    /* increase the number of RX queues */
+    if (q_head == &lcore->lcore_rx_head)
+        lcore->lcore_nb_rx_queues++;
+}
+
+/* Flush and remove TX queue from a lcore
+ * The function is called by each forwaring lcore
+ */
+static void
+dpdk_lcore_tx_queue_remove(struct vr_dpdk_lcore *lcore,
+                            struct vr_dpdk_queue *tx_queue)
+{
+    tx_queue->txq_ops.f_tx = NULL;
+    SLIST_REMOVE(&lcore->lcore_tx_head, tx_queue, vr_dpdk_queue,
+        q_next);
+    tx_queue->txq_ops.f_flush(tx_queue->q_queue_h);
+}
+
+/* Remove RX queue from a lcore
+ * The function is called by each forwaring lcore
+ */
+static void
+dpdk_lcore_rx_queue_remove(struct vr_dpdk_lcore *lcore,
+                            struct vr_dpdk_queue *rx_queue)
+{
+    rx_queue->rxq_ops.f_rx = NULL;
+    SLIST_REMOVE(&lcore->lcore_rx_head, rx_queue, vr_dpdk_queue,
+        q_next);
+
+    /* decrease the number of RX queues */
+    lcore->lcore_nb_rx_queues--;
+    RTE_VERIFY(lcore->lcore_nb_rx_queues < VR_MAX_INTERFACES);
+}
+
+/* Schedule an MPLS label queue */
+int
+vr_dpdk_lcore_mpls_schedule(struct vr_interface *vif, unsigned dst_ip,
+    unsigned mpls_label)
+{
+    int ret;
+    uint16_t queue_id;
+    struct vr_dpdk_queue *rx_queue;
+    unsigned least_used_id = vr_dpdk_lcore_least_used_get();
+
+    if (least_used_id == RTE_MAX_LCORE) {
+        RTE_LOG(ERR, VROUTER, "\terror getting the least used lcore ID\n");
+        return -EFAULT;
+    }
+
+    queue_id = vr_dpdk_ethdev_ready_queue_id_get(vif);
+    if (queue_id == VR_DPDK_INVALID_QUEUE_ID)
+        return -ENOMEM;
+
+    /* add hardware filter */
+    ret = vr_dpdk_ethdev_filter_add(vif, queue_id, dst_ip, mpls_label);
+    if (ret < 0)
+        return ret;
+
+    /* init RX queue */
+    RTE_LOG(INFO, VROUTER, "\tlcore %u RX from filtering queue %" PRIu16
+        " MPLS %u\n", least_used_id, queue_id, mpls_label);
+    rx_queue = vr_dpdk_ethdev_rx_queue_init(least_used_id, vif, queue_id);
+    if (rx_queue == NULL)
+        return -EFAULT;
+
+    /* add the queue to the lcore */
+    dpdk_lcore_queue_add(least_used_id, &vr_dpdk.lcores[least_used_id]->lcore_rx_head,
+                        rx_queue);
+
+    return 0;
+}
+
+/* Schedule an interface */
+int
+vr_dpdk_lcore_if_schedule(struct vr_interface *vif, unsigned least_used_id,
+    uint16_t nb_rx_queues, vr_dpdk_queue_init_op rx_queue_init_op,
+    uint16_t nb_tx_queues, vr_dpdk_queue_init_op tx_queue_init_op)
+{
+    unsigned lcore_id;
+    uint16_t queue_id;
+    struct vr_dpdk_queue *rx_queue;
+    struct vr_dpdk_queue *tx_queue;
+    struct vr_dpdk_lcore *lcore;
+
+    if (least_used_id == RTE_MAX_LCORE) {
+        RTE_LOG(ERR, VROUTER, "\terror getting the least used lcore ID\n");
+        return -EFAULT;
+    }
+
+    /* init TX queues starting with the least used lcore */
+    lcore_id = least_used_id;
+    queue_id = 0;
+    /* for all lcores */
+    do {
+        /* never use netlink lcore */
+        lcore = vr_dpdk.lcores[lcore_id];
+        if (lcore->lcore_nb_rx_queues >= VR_MAX_INTERFACES) {
+            /* do not skip master lcore but wrap */
+            lcore_id = rte_get_next_lcore(lcore_id, 0, 1);
+            continue;
+        }
+
+        /* init hardware or ring queue */
+        if (((lcore_id != vr_dpdk.packet_lcore_id) ||
+                    (nb_tx_queues > vr_dpdk.nb_fwd_lcores)) &&
+                (queue_id < nb_tx_queues)) {
+            /* there is a hardware queue available */
+            RTE_LOG(INFO, VROUTER, "\tlcore %u TX to HW queue %" PRIu16 "\n",
+                lcore_id, queue_id);
+            tx_queue = (*tx_queue_init_op)(lcore_id, vif, queue_id);
+            if (tx_queue == NULL)
+                return -EFAULT;
+            /* next queue */
+            queue_id++;
+        } else {
+            /* no more hardware queues left, so we use rings instead */
+            RTE_LOG(INFO, VROUTER, "\tlcore %u TX to SW ring\n", lcore_id);
+            tx_queue = vr_dpdk_ring_tx_queue_init(lcore_id, vif, least_used_id);
+            if (tx_queue == NULL)
+                return -EFAULT;
+        }
+
+        /* add the queue to the lcore */
+        dpdk_lcore_queue_add(lcore_id, &lcore->lcore_tx_head, tx_queue);
+
+        /* do not skip master lcore but wrap */
+        lcore_id = rte_get_next_lcore(lcore_id, 0, 1);
+    } while (lcore_id != least_used_id);
+
+    /* init RX queues starting with the least used lcore */
+    lcore_id = least_used_id;
+    queue_id = 0;
+    /* for all lcores */
+    do {
+        /* never use service lcores */
+        lcore = vr_dpdk.lcores[lcore_id];
+        if (lcore->lcore_nb_rx_queues >= VR_MAX_INTERFACES) {
+            /* do not skip master lcore but wrap */
+            lcore_id = rte_get_next_lcore(lcore_id, 0, 1);
+            continue;
+        }
+
+        /* init hardware queue */
+        if (lcore_id != vr_dpdk.packet_lcore_id) {
+            if (queue_id < nb_rx_queues) {
+                /* there is a hardware queue available */
+                RTE_LOG(INFO, VROUTER, "\tlcore %u RX from HW queue %" PRIu16
+                        "\n", lcore_id, queue_id);
+                rx_queue = (*rx_queue_init_op)(lcore_id, vif, queue_id);
+                if (rx_queue == NULL)
+                    return -EFAULT;
+
+                /* add the queue to the lcore */
+                dpdk_lcore_queue_add(lcore_id, &lcore->lcore_rx_head, rx_queue);
+
+                /* next queue */
+                queue_id++;
+            } else {
+                /* break if no more hardware queues left */
+                break;
+            }
+        }
+
+        /* do not skip master lcore but wrap */
+        lcore_id = rte_get_next_lcore(lcore_id, 0, 1);
+    } while (lcore_id != least_used_id);
+
+    return 0;
+}
+
+/* Post an lcore command */
+void
+vr_dpdk_lcore_cmd_post(struct vr_dpdk_lcore *lcore, uint16_t cmd,
+    uint32_t cmd_param)
+{
+    uint64_t event = 1;
+
+    rte_atomic32_set(&lcore->lcore_cmd_param, cmd_param);
+    rte_atomic16_set(&lcore->lcore_cmd, cmd);
+
+    /* wake up the pkt0 thread */
+    if (lcore->lcore_event_sock) {
+        vr_usocket_write(lcore->lcore_event_sock, (unsigned char *)&event,
+                sizeof(event));
+    }
+}
+
+/* Wait for the command completion */
+static void
+dpdk_lcore_cmd_wait(struct vr_dpdk_lcore *lcore)
+{
+    while (rte_atomic16_read(&lcore->lcore_cmd) != VR_DPDK_LCORE_NO_CMD);
+}
+
+/* Release RX and TX queues
+ * The function is called by the NetLink lcore only.
+ */
+void
+dpdk_lcore_rxtx_release(unsigned lcore_id, struct vr_interface *vif)
+{
+    struct vr_dpdk_lcore *lcore = vr_dpdk.lcores[lcore_id];
+    struct vr_dpdk_queue_params *rx_queue_params;
+    struct vr_dpdk_queue_params *tx_queue_params;
+
+    rx_queue_params = &lcore->lcore_rx_queue_params[vif->vif_idx];
+    if (rx_queue_params->qp_release_op) {
+        RTE_LOG(INFO, VROUTER, "\treleasing lcore %u RX queue\n", lcore_id);
+        rx_queue_params->qp_release_op(lcore_id, vif);
+    }
+
+    tx_queue_params = &lcore->lcore_tx_queue_params[vif->vif_idx];
+    if (tx_queue_params->qp_release_op) {
+        RTE_LOG(INFO, VROUTER, "\treleasing lcore %u TX queue\n", lcore_id);
+        tx_queue_params->qp_release_op(lcore_id, vif);
+    }
+}
+
+/* Unschedule an interface */
+void
+vr_dpdk_lcore_if_unschedule(struct vr_interface *vif)
+{
+    unsigned lcore_id;
+    struct vr_dpdk_lcore *lcore;
+
+    /* remove RX queues first */
+    RTE_LCORE_FOREACH(lcore_id) {
+        lcore = vr_dpdk.lcores[lcore_id];
+        /* never use netlink lcore */
+        if (lcore->lcore_nb_rx_queues >= VR_MAX_INTERFACES)
+            continue;
+        vr_dpdk_lcore_cmd_post(lcore, VR_DPDK_LCORE_RX_RM_CMD,
+                        (uint32_t)vif->vif_idx);
+    }
+    RTE_LCORE_FOREACH(lcore_id) {
+        lcore = vr_dpdk.lcores[lcore_id];
+        dpdk_lcore_cmd_wait(lcore);
+    }
+
+    /* flush and remove TX queues */
+    RTE_LCORE_FOREACH(lcore_id) {
+        /* never use service lcores */
+        lcore = vr_dpdk.lcores[lcore_id];
+        if (lcore->lcore_nb_rx_queues >= VR_MAX_INTERFACES)
+            continue;
+        vr_dpdk_lcore_cmd_post(lcore, VR_DPDK_LCORE_TX_RM_CMD,
+                        (uint32_t)vif->vif_idx);
+    }
+    RTE_LCORE_FOREACH(lcore_id) {
+        lcore = vr_dpdk.lcores[lcore_id];
+        dpdk_lcore_cmd_wait(lcore);
+    }
+
+    /* release RX and TX queues */
+    RTE_LCORE_FOREACH(lcore_id) {
+        dpdk_lcore_rxtx_release(lcore_id, vif);
+    }
+}
+
+/* Send a burst of packets to vRouter */
+static inline void
+dpdk_vroute(struct vr_interface *vif, struct rte_mbuf *pkts[VR_DPDK_MAX_BURST_SZ],
+    uint32_t nb_pkts)
+{
+    unsigned i;
+    struct rte_mbuf *mbuf;
+    struct vr_packet *pkt;
+    unsigned lcore_id;
+    struct vr_dpdk_lcore * lcore;
+    struct vr_dpdk_queue *monitoring_tx_queue;
+    struct vr_packet *p_clone;
+
+    RTE_LOG(DEBUG, VROUTER, "%s: RX %" PRIu32 " packet(s) from interface %s\n",
+         __func__, nb_pkts, vif->vif_name);
+
+    if (unlikely(vif->vif_flags & VIF_FLAG_MONITORED)) {
+        lcore_id = rte_lcore_id();
+        lcore = vr_dpdk.lcores[lcore_id];
+        monitoring_tx_queue = &lcore->lcore_tx_queues[vr_dpdk.monitorings[vif->vif_idx]];
+        if (likely(monitoring_tx_queue && monitoring_tx_queue->txq_ops.f_tx)) {
+            for (i = 0; i < nb_pkts; i++) {
+                mbuf = pkts[i];
+
+                rte_prefetch0(vr_dpdk_mbuf_to_pkt(mbuf));
+                rte_prefetch0(rte_pktmbuf_mtod(mbuf, void *));
+
+                /* convert mbuf to vr_packet */
+                pkt = vr_dpdk_packet_get(mbuf, vif);
+                p_clone = vr_pclone(pkt);
+                if (likely(p_clone != NULL))
+                    monitoring_tx_queue->txq_ops.f_tx(monitoring_tx_queue->q_queue_h,
+                        vr_dpdk_pkt_to_mbuf(p_clone));
+            }
+        }
+    }
+
+    for (i = 0; i < nb_pkts; i++) {
+        mbuf = pkts[i];
+#ifdef VR_DPDK_RX_PKT_DUMP
+        rte_pktmbuf_dump(stdout, mbuf, 0x60);
+#endif
+        rte_prefetch0(vr_dpdk_mbuf_to_pkt(mbuf));
+        rte_prefetch0(rte_pktmbuf_mtod(mbuf, void *));
+
+        /* convert mbuf to vr_packet */
+        pkt = vr_dpdk_packet_get(mbuf, vif);
+        /* send the packet to vRouter */
+        vif->vif_rx(vif, pkt, VLAN_ID_INVALID);
+    }
+}
+
+/* Send a burst of vr_packets to vRouter */
+void
+vr_dpdk_packets_vroute(struct vr_interface *vif, struct vr_packet *pkts[VR_DPDK_MAX_BURST_SZ], uint32_t nb_pkts)
+{
+    unsigned i;
+    struct vr_packet *pkt;
+    unsigned lcore_id;
+    struct vr_dpdk_lcore * lcore;
+    struct vr_dpdk_queue *monitoring_tx_queue;
+    struct vr_packet *p_clone;
+
+    RTE_LOG(DEBUG, VROUTER, "%s: RX %" PRIu32 " packet(s) from interface %s\n",
+         __func__, nb_pkts, vif->vif_name);
+
+    if (unlikely(vif->vif_flags & VIF_FLAG_MONITORED)) {
+        lcore_id = rte_lcore_id();
+        lcore = vr_dpdk.lcores[lcore_id];
+        monitoring_tx_queue = &lcore->lcore_tx_queues[vr_dpdk.monitorings[vif->vif_idx]];
+        if (likely(monitoring_tx_queue && monitoring_tx_queue->txq_ops.f_tx)) {
+            for (i = 0; i < nb_pkts; i++) {
+                pkt = pkts[i];
+                rte_prefetch0(pkt);
+
+                p_clone = vr_pclone(pkt);
+                if (likely(p_clone != NULL))
+                    monitoring_tx_queue->txq_ops.f_tx(monitoring_tx_queue->q_queue_h,
+                        vr_dpdk_pkt_to_mbuf(p_clone));
+            }
+        }
+    }
+
+    for (i = 0; i < nb_pkts; i++) {
+        pkt = pkts[i];
+#ifdef VR_DPDK_RX_PKT_DUMP
+        rte_pktmbuf_dump(stdout, vr_dpdk_pkt_to_mbuf(pkt), 0x60);
+#endif
+        rte_prefetch0(pkt);
+
+        /* send the packet to vRouter */
+        vif->vif_rx(vif, pkt, VLAN_ID_INVALID);
+    }
+}
+
+/* Forwarding lcore RX */
+static inline uint32_t
+dpdk_lcore_fwd_rx(struct vr_dpdk_lcore *lcore)
+{
+    uint64_t total_pkts = 0;
+    struct rte_mbuf *pkts[VR_DPDK_MAX_BURST_SZ];
+    struct vr_dpdk_queue *rx_queue;
+    uint32_t nb_pkts;
+    struct vr_packet *pkt_arr[VR_DPDK_MAX_BURST_SZ];
+    int pkti;
+
+    /* for all RX queues */
+    SLIST_FOREACH(rx_queue, &lcore->lcore_rx_head, q_next) {
+        /* burst RX */
+        nb_pkts = rx_queue->rxq_ops.f_rx(rx_queue->q_queue_h, pkts,
+                rx_queue->rxq_burst_size);
+        if (likely(nb_pkts > 0)) {
+            total_pkts += nb_pkts;
+            /* transmit packets to vrouter */
+            if (vif_is_virtual(rx_queue->q_vif)) {
+                for (pkti = 0; pkti < nb_pkts; pkti++) {
+                    pkt_arr[pkti] = vr_dpdk_packet_get(pkts[pkti],
+                                                       rx_queue->q_vif);
+                }
+                vr_dpdk_virtio_enq_pkts_to_phys_lcore(rx_queue,
+                                                      pkt_arr, nb_pkts);
+            } else {
+                dpdk_vroute(rx_queue->q_vif, pkts, nb_pkts);
+            }
+        }
+    }
+    return total_pkts;
+}
+
+/* Forwarding lcore IO */
+static inline void
+dpdk_lcore_fwd_io(struct vr_dpdk_lcore *lcore)
+{
+    uint64_t total_pkts = 0;
+    struct rte_mbuf *pkts[VR_DPDK_MAX_BURST_SZ];
+    uint32_t nb_pkts;
+    int i;
+    struct vr_dpdk_ring_to_push *rtp;
+    uint16_t nb_rtp;
+
+    /* TODO: skip RX queues with no packets to read
+     * RX operation for KNIs is quite expensive. We used rx_queue_mask to
+     * mask out the ports with no packets to read (i.e. read them less
+     * frequently). We need to implement the same functionality for the
+     * list of RX queues now.
+     */
+    total_pkts += dpdk_lcore_fwd_rx(lcore);
+
+    /* for all TX rings to push */
+    rtp = &lcore->lcore_rings_to_push[0];
+    nb_rtp = lcore->lcore_nb_rings_to_push;
+    while (nb_rtp > 0) {
+        nb_rtp--;
+        if (unlikely(rtp->rtp_tx_ring == NULL)) {
+            rtp++;
+            continue;
+        }
+
+        nb_pkts = rte_ring_sc_dequeue_burst(rtp->rtp_tx_ring, (void **)pkts,
+            VR_DPDK_MAX_BURST_SZ-1);
+        if (likely(nb_pkts != 0)) {
+            total_pkts += nb_pkts;
+
+            if (likely(rtp->rtp_tx_queue && rtp->rtp_tx_queue->txq_ops.f_tx)) {
+                /* push packets to the TX queue */
+                /* TODO: use f_tx_bulk instead */
+                for (i = 0; i < nb_pkts; i++) {
+                    rtp->rtp_tx_queue->txq_ops.f_tx(
+                        rtp->rtp_tx_queue->q_queue_h, pkts[i]);
+                }
+            } else {
+                vr_dpdk_packets_vroute(((struct vr_packet*)pkts[0])->vp_if,
+                    (struct vr_packet**)pkts, nb_pkts);
+            }
+        }
+        rtp++;
+    }
+
+    rcu_quiescent_state();
+
+#if VR_DPDK_SLEEP_NO_PACKETS_US > 0
+    /* sleep if no single packet received */
+    if (unlikely(total_pkts == 0)) {
+        usleep(VR_DPDK_SLEEP_NO_PACKETS_US);
+    }
+#endif
+#if VR_DPDK_YIELD_NO_PACKETS > 0
+    /* yield if no single packet received */
+    if (unlikely(total_pkts == 0)) {
+        sched_yield();
+    }
+#endif
+}
+
+/* Init forwarding lcore */
+static int
+dpdk_lcore_init(void)
+{
+    const unsigned lcore_id = rte_lcore_id();
+    struct vr_dpdk_lcore *lcore;
+
+    /* allocate lcore context */
+    lcore = rte_zmalloc_socket("vr_dpdk_lcore", sizeof(struct vr_dpdk_lcore),
+        CACHE_LINE_SIZE, rte_socket_id());
+    if (lcore == NULL) {
+        RTE_LOG(CRIT, VROUTER, "Error allocating lcore %u context\n", lcore_id);
+        return -ENOMEM;
+    }
+
+    /* init lcore lists */
+    SLIST_INIT(&lcore->lcore_tx_head);
+
+    vr_dpdk.lcores[lcore_id] = lcore;
+
+    rcu_register_thread();
+    rcu_thread_offline();
+
+    return 0;
+}
+
+/* Exit forwarding lcore */
+static void
+dpdk_lcore_exit()
+{
+    const unsigned lcore_id = rte_lcore_id();
+    struct vr_dpdk_lcore *lcore = vr_dpdk.lcores[lcore_id];
+
+    rcu_unregister_thread();
+
+    /* free lcore context */
+    vr_dpdk.lcores[lcore_id] = NULL;
+    rte_free(lcore);
+}
+
+/* Handle an IPC command
+ * Returns -1 if if there is a stop command
+ */
+int
+vr_dpdk_lcore_cmd_handle(struct vr_dpdk_lcore *lcore)
+{
+    uint16_t cmd = (uint16_t)rte_atomic16_read(&lcore->lcore_cmd);
+    uint32_t cmd_param = (uint32_t)rte_atomic32_read(&lcore->lcore_cmd_param);
+    int ret = 0;
+    unsigned vif_idx;
+    struct vr_dpdk_queue *rx_queue;
+    struct vr_dpdk_queue *tx_queue;
+
+    if (likely(cmd == VR_DPDK_LCORE_NO_CMD))
+        return 0;
+
+    switch (cmd) {
+    case VR_DPDK_LCORE_RX_RM_CMD:
+        vif_idx = cmd_param;
+        rx_queue = &lcore->lcore_rx_queues[vif_idx];
+        if (rx_queue->q_queue_h) {
+            /* remove the queue from the lcore */
+            dpdk_lcore_rx_queue_remove(lcore, rx_queue);
+        }
+        break;
+    case VR_DPDK_LCORE_TX_RM_CMD:
+        vif_idx = cmd_param;
+        tx_queue = &lcore->lcore_tx_queues[vif_idx];
+        if (tx_queue->q_queue_h) {
+            /* remove the queue from the lcore */
+            dpdk_lcore_tx_queue_remove(lcore, tx_queue);
+        }
+        break;
+    case VR_DPDK_LCORE_STOP_CMD:
+        ret = -1;
+        break;
+    }
+
+    rte_atomic16_set(&lcore->lcore_cmd, VR_DPDK_LCORE_NO_CMD);
+    rte_wmb();
+
+    return ret;
+}
+
+/* Forwarding lcore main loop */
+int
+dpdk_lcore_fwd_loop(struct vr_dpdk_lcore *lcore)
+{
+    /* cycles counters */
+    uint64_t cur_cycles = 0;
+    uint64_t diff_cycles;
+    uint64_t last_tx_cycles = 0;
+#if VR_DPDK_USE_TIMER
+    /* calculate timeouts in CPU cycles */
+    const uint64_t tx_flush_cycles = (rte_get_timer_hz() + US_PER_S - 1)
+        * VR_DPDK_TX_FLUSH_US / US_PER_S;
+#else
+    const uint64_t tx_flush_cycles = VR_DPDK_TX_FLUSH_LOOPS;
+#endif
+
+    RTE_LOG(DEBUG, VROUTER, "Hello from forwarding lcore %u\n", rte_lcore_id());
+
+    while (1) {
+        rte_prefetch0(lcore);
+
+        /* update cycles counter */
+#if VR_DPDK_USE_TIMER
+        cur_cycles = rte_get_timer_cycles();
+#else
+        cur_cycles++;
+#endif
+
+        /* run forwarding lcore IO */
+        dpdk_lcore_fwd_io(lcore);
+
+        /* check if we need to flush TX queues */
+        diff_cycles = cur_cycles - last_tx_cycles;
+        if (unlikely(tx_flush_cycles < diff_cycles)) {
+            /* update TX flush cycles */
+            last_tx_cycles = cur_cycles;
+
+            /* flush all TX queues */
+            vr_dpdk_lcore_flush(lcore);
+
+            if (unlikely(lcore->lcore_nb_rx_queues == 0)) {
+                /* no queues to poll -> sleep a bit */
+                usleep(VR_DPDK_SLEEP_NO_QUEUES_US);
+            }
+
+            /* handle an IPC command */
+            if (unlikely(vr_dpdk_lcore_cmd_handle(lcore)))
+                break;
+        } /* flush TX queues */
+    } /* lcore loop */
+
+    RTE_LOG(DEBUG, VROUTER, "Bye-bye from forwarding lcore %u\n", rte_lcore_id());
+
+    return 0;
+}
+
+/* Service lcore main loop */
+int
+dpdk_lcore_service_loop(struct vr_dpdk_lcore *lcore, unsigned netlink_lcore_id,
+    unsigned packet_lcore_id)
+{
+    unsigned lcore_id = rte_lcore_id();
+
+    RTE_LOG(DEBUG, VROUTER, "Hello from service lcore %u\n", rte_lcore_id());
+
+    /* never schedule interfaces on the service lcore */
+    if (lcore_id != packet_lcore_id) {
+        lcore->lcore_nb_rx_queues = VR_MAX_INTERFACES;
+    } else {
+        vr_dpdk.packet_lcore_id = packet_lcore_id;
+    }
+
+    while (1) {
+        rte_prefetch0(lcore);
+
+        if (lcore_id == netlink_lcore_id) {
+            RTE_LOG(DEBUG, VROUTER, "%s: NetLink IO on lcore %u\n",
+                __func__, rte_lcore_id());
+            dpdk_netlink_io();
+        }
+
+        if (lcore_id == packet_lcore_id) {
+            RTE_LOG(DEBUG, VROUTER, "%s: packet IO on lcore %u\n",
+                __func__, rte_lcore_id());
+            dpdk_packet_io();
+        }
+
+        if (netlink_lcore_id != packet_lcore_id)
+            break;
+
+        usleep(VR_DPDK_SLEEP_SERVICE_US);
+        /* handle an IPC command */
+        if (unlikely(vr_dpdk_lcore_cmd_handle(lcore)))
+            break;
+    } /* lcore loop */
+
+    RTE_LOG(DEBUG, VROUTER, "Bye-bye from service lcore %u\n", rte_lcore_id());
+
+    return 0;
+}
+
+/* Launch lcore main loop */
+int
+vr_dpdk_lcore_launch(__attribute__((unused)) void *dummy)
+{
+    const unsigned lcore_id = rte_lcore_id();
+    struct vr_dpdk_lcore *lcore;
+    const unsigned netlink_lcore_id = rte_get_master_lcore();
+    /* skip master lcore and wrap */
+    unsigned packet_lcore_id = rte_get_next_lcore(netlink_lcore_id, 1, 1);
+
+    /* init forwarding lcore */
+    if (dpdk_lcore_init() != 0)
+        return -ENOMEM;
+
+    /* set current lcore context */
+    lcore = vr_dpdk.lcores[lcore_id];
+
+    if (rte_lcore_count() == VR_DPDK_MIN_LCORES) {
+        /* use master lcore for packet and NetLink handling */
+        packet_lcore_id = netlink_lcore_id;
+    }
+
+    if (lcore_id == netlink_lcore_id || lcore_id == packet_lcore_id)
+        dpdk_lcore_service_loop(lcore, netlink_lcore_id, packet_lcore_id);
+    else
+        dpdk_lcore_fwd_loop(lcore);
+
+    /* exit forwarding lcore */
+    dpdk_lcore_exit();
+
+    return 0;
+}

--- a/dpdk/vr_dpdk_lcore.c
+++ b/dpdk/vr_dpdk_lcore.c
@@ -292,16 +292,11 @@ void
 vr_dpdk_lcore_cmd_post(struct vr_dpdk_lcore *lcore, uint16_t cmd,
     uint32_t cmd_param)
 {
-    uint64_t event = 1;
-
     rte_atomic32_set(&lcore->lcore_cmd_param, cmd_param);
     rte_atomic16_set(&lcore->lcore_cmd, cmd);
 
     /* wake up the pkt0 thread */
-    if (lcore->lcore_event_sock) {
-        vr_usocket_write(lcore->lcore_event_sock, (unsigned char *)&event,
-                sizeof(event));
-    }
+    vr_dpdk_packet_tx(lcore);
 }
 
 /* Wait for the command completion */

--- a/dpdk/vr_dpdk_lcore.c
+++ b/dpdk/vr_dpdk_lcore.c
@@ -37,6 +37,8 @@ vr_dpdk_phys_lcore_least_used_get(void)
     unsigned int num_queues;
 
     RTE_LCORE_FOREACH(lcore_id) {
+        if (lcore_id == vr_dpdk.packet_lcore_id)
+            continue;
         lcore = vr_dpdk.lcores[lcore_id];
         num_queues = lcore->lcore_nb_rx_queues + lcore->lcore_nb_rings_to_push;
 

--- a/dpdk/vr_dpdk_lcore.c
+++ b/dpdk/vr_dpdk_lcore.c
@@ -411,6 +411,9 @@ dpdk_vroute(struct vr_interface *vif, struct rte_mbuf *pkts[VR_DPDK_MAX_BURST_SZ
     for (i = 0; i < nb_pkts; i++) {
         mbuf = pkts[i];
 #ifdef VR_DPDK_RX_PKT_DUMP
+#ifdef VR_DPDK_PKT_DUMP_VIF_FILTER
+        if (VR_DPDK_PKT_DUMP_VIF_FILTER(vif))
+#endif
         rte_pktmbuf_dump(stdout, mbuf, 0x60);
 #endif
         rte_prefetch0(vr_dpdk_mbuf_to_pkt(mbuf));
@@ -457,6 +460,9 @@ vr_dpdk_packets_vroute(struct vr_interface *vif, struct vr_packet *pkts[VR_DPDK_
     for (i = 0; i < nb_pkts; i++) {
         pkt = pkts[i];
 #ifdef VR_DPDK_RX_PKT_DUMP
+#ifdef VR_DPDK_PKT_DUMP_VIF_FILTER
+        if (VR_DPDK_PKT_DUMP_VIF_FILTER(vif))
+#endif
         rte_pktmbuf_dump(stdout, vr_dpdk_pkt_to_mbuf(pkt), 0x60);
 #endif
         rte_prefetch0(pkt);

--- a/dpdk/vr_dpdk_netlink.c
+++ b/dpdk/vr_dpdk_netlink.c
@@ -1,0 +1,302 @@
+/*
+ * vr_dpdk_netlink.c -- message handling from agent
+ *
+ * Copyright (c) 2014, Juniper Networks Private Inc.,
+ * All rights reserved
+ */
+#include <stdio.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <sys/un.h>
+
+#include <linux/netlink.h>
+#include <linux/genetlink.h>
+
+#include "vr_queue.h"
+#include "vr_dpdk_usocket.h"
+#include "vr_message.h"
+#include "vr_dpdk.h"
+#include "vr_genetlink.h"
+#include "vr_uvhost.h"
+#include "vr_uvhost_msg.h"
+
+#define HDR_LEN (NLMSG_HDRLEN + GENL_HDRLEN + sizeof(struct nlattr))
+
+struct nlmsghdr *dpdk_nl_message_hdr(struct vr_message *);
+unsigned int dpdk_nl_message_len(struct vr_message *);
+
+int vr_usocket_message_write(struct vr_usocket *, struct vr_message *);
+int vr_nl_uvh_sock;
+
+static void
+dpdk_nl_process_response(void *usockp, struct nlmsghdr *nlh)
+{
+    __u32 seq;
+    unsigned int multi_flag = 0;
+    bool write = true;
+
+    struct vr_message *resp;
+
+    struct nlmsghdr *resp_nlh;
+    struct genlmsghdr *genlh, *resp_genlh;
+    struct nlattr *resp_nla;
+
+    seq = nlh->nlmsg_seq;
+    genlh = (struct genlmsghdr *)((unsigned char *)nlh + NLMSG_HDRLEN);
+
+    /* Process responses */
+    while ((resp = (struct vr_message *)vr_message_dequeue_response())) {
+        if (!write) {
+            vr_message_free(resp);
+            continue;
+        }
+
+        if (!vr_response_queue_empty()) {
+            multi_flag = NLM_F_MULTI;
+        } else {
+            multi_flag = 0;
+        }
+
+        resp->vr_message_len = RTE_ALIGN(resp->vr_message_len, 4);
+
+        /* Update Netlink headers */
+        resp_nlh = dpdk_nl_message_hdr(resp);
+        resp_nlh->nlmsg_len = dpdk_nl_message_len(resp);
+        resp_nlh->nlmsg_type = nlh->nlmsg_type;
+        resp_nlh->nlmsg_flags = multi_flag;
+        resp_nlh->nlmsg_seq = seq;
+        resp_nlh->nlmsg_pid = 0;
+
+        resp_genlh = (struct genlmsghdr *)((unsigned char *)resp_nlh +
+                NLMSG_HDRLEN);
+        memcpy(resp_genlh, genlh, sizeof(*genlh));
+
+        resp_nla = (struct nlattr *)((unsigned char *)resp_genlh + GENL_HDRLEN);
+        resp_nla->nla_len = resp->vr_message_len;
+        resp_nla->nla_type = NL_ATTR_VR_MESSAGE_PROTOCOL;
+
+        if (vr_usocket_message_write(usockp, resp) < 0) {
+            write = false;
+            vr_usocket_close(usockp);
+        }
+    }
+
+    return;
+}
+
+int
+dpdk_netlink_receive(void *usockp, char *nl_buf,
+        unsigned int nl_len)
+{
+    struct vr_message request;
+
+    request.vr_message_buf = nl_buf + HDR_LEN;
+    request.vr_message_len = nl_len - HDR_LEN;
+    vr_message_request(&request);
+
+    dpdk_nl_process_response(usockp, (struct nlmsghdr *)nl_buf);
+
+    return 0;
+}
+
+unsigned int
+dpdk_nl_message_len(struct vr_message *message)
+{
+    return message->vr_message_len + HDR_LEN;
+}
+
+struct nlmsghdr *
+dpdk_nl_message_hdr(struct vr_message *message)
+{
+    return (struct nlmsghdr *)(message->vr_message_buf - HDR_LEN);
+}
+
+static void
+dpdk_nl_trans_free(char *buf)
+{
+    buf -= HDR_LEN;
+    vr_free(buf);
+
+    return;
+}
+
+static char *
+dpdk_nl_trans_alloc(unsigned int size)
+{
+    char *buf;
+
+    buf = vr_malloc(size + HDR_LEN);
+    if (!buf)
+        return NULL;
+
+    return buf + HDR_LEN;
+}
+
+static struct vr_mtransport dpdk_nl_transport = {
+    .mtrans_alloc       =       dpdk_nl_trans_alloc,
+    .mtrans_free        =       dpdk_nl_trans_free,
+};
+
+/*
+ * vr_netlink_uvhost_vif_del - sends a message to the user space vhost
+ * thread when a vif is deleted. vif_idx is the index of the vif.
+ *
+ * Returns 0 on success, -1 otherwise.
+ */
+int
+vr_netlink_uvhost_vif_del(int vif_idx)
+{
+    vrnu_msg_t msg;
+
+    msg.vrnum_type = VRNU_MSG_VIF_DEL;
+    msg.vrnum_vif_del.vrnu_vif_idx = vif_idx;
+
+    /*
+     * This is a blocking send.
+     */
+    if (send(vr_nl_uvh_sock, (void *) &msg, sizeof(msg), 0) !=
+             sizeof(msg)) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
+ * vr_netlink_uvhost_vif_add - sends a message to the user space vhost
+ * thread when a new vif is created. The name os the vif is specified in
+ * the vif_name argument.
+ *
+ * Returns 0 on success, -1 otherwise.
+ */
+int
+vr_netlink_uvhost_vif_add(char *vif_name, unsigned int vif_idx,
+                          unsigned int vif_nrxqs, unsigned int vif_ntxqs)
+{
+    vrnu_msg_t msg;
+
+    msg.vrnum_type = VRNU_MSG_VIF_ADD;
+    strncpy(msg.vrnum_vif_add.vrnu_vif_name, vif_name,
+            sizeof(msg.vrnum_vif_add.vrnu_vif_name) - 1);
+    msg.vrnum_vif_add.vrnu_vif_idx = vif_idx;
+    msg.vrnum_vif_add.vrnu_vif_nrxqs = vif_nrxqs;
+    msg.vrnum_vif_add.vrnu_vif_ntxqs = vif_ntxqs;
+
+    /*
+     * This is a blocking send.
+     */
+    if (send(vr_nl_uvh_sock, (void *) &msg, sizeof(msg), 0) !=
+             sizeof(msg)) {
+        RTE_LOG(ERR, VROUTER, "\terror adding vif to user space vhost:"
+            " send error\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+int
+dpdk_netlink_io(void)
+{
+    return vr_usocket_io(vr_dpdk.netlink_sock);
+}
+
+void
+dpdk_netlink_exit(void)
+{
+    vr_message_transport_unregister(&dpdk_nl_transport);
+    vr_usocket_close(vr_dpdk.netlink_sock);
+
+    return;
+}
+
+/*
+ * vr_nl_uvhost_connect - connect to the user space vhost server on a UNIX
+ * domain socket.
+ *
+ * Returns 0 on success, error otherwise.
+ */
+static int
+vr_nl_uvhost_connect(void)
+{
+    int s = 0, ret = -1;
+    struct sockaddr_un nl_sun, uvh_sun;
+
+    RTE_LOG(INFO, VROUTER, "Starting NetLink...\n");
+    s = socket(AF_UNIX, SOCK_SEQPACKET, 0);
+    if (s == -1) {
+        RTE_LOG(ERR, VROUTER, "\terror connecting to NetLink: %s (%d)\n",
+                        strerror(errno), errno);
+        goto error;
+    }
+    RTE_LOG(INFO, VROUTER, "\tNetLink socket FD is %d\n", s);
+
+    unlink(VR_NL_UVH_SOCK);
+    memset(&nl_sun, 0, sizeof(nl_sun));
+    nl_sun.sun_family = AF_UNIX;
+    strncpy(nl_sun.sun_path, VR_NL_UVH_SOCK, sizeof(nl_sun.sun_path) - 1);
+
+    ret = bind(s, (struct sockaddr *) &nl_sun, sizeof(nl_sun));
+    if (ret == -1) {
+        RTE_LOG(ERR, VROUTER, "\terror binding NetLink FD %d to %s: %s (%d)\n",
+                        s, nl_sun.sun_path, strerror(errno), errno);
+        goto error;
+    }
+
+    /*
+     * This will block until the user space vhost thread listens on the
+     * socket.
+     */
+    memset(&uvh_sun, 0, sizeof(uvh_sun));
+    uvh_sun.sun_family = AF_UNIX;
+    strncpy(uvh_sun.sun_path, VR_UVH_NL_SOCK, sizeof(uvh_sun.sun_path) - 1);
+    ret = connect(s, (struct sockaddr *) &uvh_sun, sizeof(uvh_sun));
+    if (ret == -1) {
+        RTE_LOG(ERR, VROUTER, "\terror connecting NetLink socket FD %d to %s: %s (%d)\n",
+                        s, uvh_sun.sun_path, strerror(errno), errno);
+        goto error;
+    }
+
+    vr_nl_uvh_sock = s;
+
+    return 0;
+
+error:
+
+    if (s > 0) {
+        close(s);
+    }
+
+    return ret;
+}
+
+int
+dpdk_netlink_init(void)
+{
+    int ret;
+    int num_cores = rte_lcore_count();
+
+    ret = vr_message_transport_register(&dpdk_nl_transport);
+    if (ret)
+        return ret;
+
+    vr_dpdk.netlink_sock = vr_usocket(NETLINK, TCP);
+    if (!vr_dpdk.netlink_sock) {
+        RTE_LOG(ERR, VROUTER, "Failed to create the NETLINK server socket\n");
+        return -1;
+    }
+
+    ret = vr_nl_uvhost_connect();
+    if (ret != 0) {
+        vr_message_transport_unregister(&dpdk_nl_transport);
+        vr_usocket_close(vr_dpdk.netlink_sock);
+
+        RTE_LOG(ERR, VROUTER, "Failed to create vhost connection\n");
+        return -1;
+    }
+
+    if (num_cores == VR_DPDK_MIN_LCORES)
+        vr_usocket_non_blocking(vr_dpdk.netlink_sock);
+
+    return 0;
+}

--- a/dpdk/vr_dpdk_netlink.c
+++ b/dpdk/vr_dpdk_netlink.c
@@ -252,7 +252,7 @@ vr_nl_uvhost_connect(void)
     memset(&uvh_sun, 0, sizeof(uvh_sun));
     uvh_sun.sun_family = AF_UNIX;
     strncpy(uvh_sun.sun_path, VR_UVH_NL_SOCK, sizeof(uvh_sun.sun_path) - 1);
-    ret = connect(s, (struct sockaddr *) &uvh_sun, sizeof(uvh_sun));
+    ret = vr_dpdk_retry_connect(s, (struct sockaddr *) &uvh_sun, sizeof(uvh_sun));
     if (ret == -1) {
         RTE_LOG(ERR, VROUTER, "\terror connecting NetLink socket FD %d to %s: %s (%d)\n",
                         s, uvh_sun.sun_path, strerror(errno), errno);

--- a/dpdk/vr_dpdk_netlink.c
+++ b/dpdk/vr_dpdk_netlink.c
@@ -199,6 +199,8 @@ vr_netlink_uvhost_vif_add(char *vif_name, unsigned int vif_idx,
 int
 dpdk_netlink_io(void)
 {
+    RTE_LOG(DEBUG, VROUTER, "%s[%lx]: FD %d\n", __func__, pthread_self(),
+                ((struct vr_usocket *)vr_dpdk.netlink_sock)->usock_fd);
     return vr_usocket_io(vr_dpdk.netlink_sock);
 }
 

--- a/dpdk/vr_dpdk_netlink.c
+++ b/dpdk/vr_dpdk_netlink.c
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #include <stdbool.h>
 #include <sys/un.h>
+#include <sys/stat.h>
 
 #include <linux/netlink.h>
 #include <linux/genetlink.h>
@@ -231,11 +232,12 @@ vr_nl_uvhost_connect(void)
     }
     RTE_LOG(INFO, VROUTER, "\tNetLink socket FD is %d\n", s);
 
-    unlink(VR_NL_UVH_SOCK);
     memset(&nl_sun, 0, sizeof(nl_sun));
     nl_sun.sun_family = AF_UNIX;
     strncpy(nl_sun.sun_path, VR_NL_UVH_SOCK, sizeof(nl_sun.sun_path) - 1);
 
+    mkdir(VR_SOCKET_DIR, VR_SOCKET_DIR_MODE);
+    unlink(nl_sun.sun_path);
     ret = bind(s, (struct sockaddr *) &nl_sun, sizeof(nl_sun));
     if (ret == -1) {
         RTE_LOG(ERR, VROUTER, "\terror binding NetLink FD %d to %s: %s (%d)\n",

--- a/dpdk/vr_dpdk_netlink.h
+++ b/dpdk/vr_dpdk_netlink.h
@@ -1,0 +1,14 @@
+/*
+ * vr_dpdk_netlink.h - header for vrouter DPDK netlink infrastructure.
+ *
+ *
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+#ifndef __VR_DPDK_NETLINK_H__
+#define __VR_DPDK_NETLINK_H__
+
+int vr_netlink_uvhost_vif_add(unsigned char *vif_name, unsigned int vif_idx,
+                              unsigned int vif_nrxqs, unsigned int vif_ntxqs);
+int vr_netlink_uvhost_vif_del(unsigned int vif_idx);
+
+#endif /* __VR_DPDK_NETLINK_H__ */

--- a/dpdk/vr_dpdk_packet.c
+++ b/dpdk/vr_dpdk_packet.c
@@ -1,0 +1,133 @@
+/*
+ * vr_dpdk_packet.c -- the packet interface
+ *
+ * Copyright (c) 2014, Juniper Networks, Inc.
+ * All rights reserved
+ */
+#include <stdio.h>
+#include <unistd.h>
+#include <stdbool.h>
+
+#include "vr_queue.h"
+#include "vr_dpdk.h"
+#include "vr_dpdk_usocket.h"
+
+int dpdk_packet_core_id = -1;
+
+int
+vr_dpdk_packet_tx(void)
+{
+    int ret;
+    uint64_t event = 1;
+    unsigned int lcore_id = rte_lcore_id();
+    struct vr_dpdk_lcore *lcorep = vr_dpdk.lcores[lcore_id];
+
+    if (lcorep->lcore_event_sock) {
+        ret = vr_usocket_write(lcorep->lcore_event_sock, (unsigned char *)&event,
+                sizeof(event));
+        if (ret < 0) {
+            vr_usocket_close(lcorep->lcore_event_sock);
+            lcorep->lcore_event_sock = NULL;
+        }
+    }
+
+    return 0;
+}
+
+int
+dpdk_packet_io(void)
+{
+    int ret;
+    struct vr_dpdk_lcore *lcore = vr_dpdk.lcores[rte_lcore_id()];
+
+wait_for_connection:
+    while (!vr_dpdk.packet_transport) {
+        /* handle an IPC command */
+        if (unlikely(vr_dpdk_lcore_cmd_handle(lcore)))
+            return -1;
+        usleep(VR_DPDK_SLEEP_SERVICE_US);
+    }
+
+    ret = vr_usocket_io(vr_dpdk.packet_transport);
+    if (ret < 0) {
+        vr_dpdk.packet_transport = NULL;
+        /* handle an IPC command */
+        if (unlikely(vr_dpdk_lcore_cmd_handle(lcore)))
+            return -1;
+        usleep(VR_DPDK_SLEEP_SERVICE_US);
+        goto wait_for_connection;
+    }
+
+    return ret;
+}
+
+void
+dpdk_packet_socket_close(void)
+{
+    void *usockp;
+
+    if (!vr_dpdk.packet_transport)
+        return;
+    usockp = vr_dpdk.packet_transport;
+
+    vr_dpdk.packet_transport = NULL;
+
+    vr_usocket_close(usockp);
+
+    return;
+}
+
+int
+dpdk_packet_socket_init(void)
+{
+    int ret, i;
+    unsigned int netlink_lcore_id = rte_lcore_id();
+    unsigned short lcore_count = rte_lcore_count();
+    struct vr_dpdk_lcore *lcorep;
+
+    vr_dpdk.packet_transport = (void *)vr_usocket(PACKET, RAW);
+    if (!vr_dpdk.packet_transport)
+        return -1;
+
+    if (lcore_count == VR_DPDK_MIN_LCORES)
+        vr_usocket_non_blocking(vr_dpdk.packet_transport);
+
+    if (!vr_dpdk.packet_ring) {
+        vr_dpdk.packet_ring = rte_ring_lookup("pkt0_tx");
+        if (!vr_dpdk.packet_ring) {
+            vr_dpdk.packet_ring = rte_ring_create("pkt0_tx", VR_DPDK_TX_RING_SZ,
+                    SOCKET_ID_ANY, 0);
+            if (!vr_dpdk.packet_ring) {
+                ret = -ENOMEM;
+                goto error;
+            }
+        }
+    }
+
+    for (i = 0; i < lcore_count; i++) {
+        if (i == netlink_lcore_id)
+            continue;
+
+        lcorep = vr_dpdk.lcores[i];
+        lcorep->lcore_event_sock = (void *)vr_usocket(EVENT, RAW);
+        if (!lcorep->lcore_event_sock) {
+            ret = -ENOMEM;
+            goto error;
+        }
+
+        if (vr_usocket_bind_usockets(vr_dpdk.packet_transport,
+                    lcorep->lcore_event_sock))
+            goto error;
+    }
+
+
+    return 0;
+
+error:
+    if (vr_dpdk.packet_transport) {
+        vr_usocket_close(vr_dpdk.packet_transport);
+        vr_dpdk.packet_transport = NULL;
+    }
+
+    return ret;
+}

--- a/dpdk/vr_dpdk_packet.c
+++ b/dpdk/vr_dpdk_packet.c
@@ -20,7 +20,7 @@ vr_dpdk_packet_wakeup(struct vr_dpdk_lcore *lcorep)
     int ret;
     uint64_t event = 1;
 
-    if (unlikely(lcorep->lcore_event_sock != NULL)) {
+    if (likely(lcorep->lcore_event_sock != NULL)) {
         ret = vr_usocket_write(lcorep->lcore_event_sock, (unsigned char *)&event,
                 sizeof(event));
         if (ret < 0) {

--- a/dpdk/vr_dpdk_packet.c
+++ b/dpdk/vr_dpdk_packet.c
@@ -37,6 +37,8 @@ dpdk_packet_io(void)
     struct vr_dpdk_lcore *lcore = vr_dpdk.lcores[rte_lcore_id()];
 
 wait_for_connection:
+    RTE_LOG(DEBUG, VROUTER, "%s[%lx]: waiting for packet transport\n",
+                __func__, pthread_self());
     while (!vr_dpdk.packet_transport) {
         /* handle an IPC command */
         if (unlikely(vr_dpdk_lcore_cmd_handle(lcore)))
@@ -44,6 +46,8 @@ wait_for_connection:
         usleep(VR_DPDK_SLEEP_SERVICE_US);
     }
 
+    RTE_LOG(DEBUG, VROUTER, "%s[%lx]: FD %d\n", __func__, pthread_self(),
+                ((struct vr_usocket *)vr_dpdk.packet_transport)->usock_fd);
     ret = vr_usocket_io(vr_dpdk.packet_transport);
     if (ret < 0) {
         vr_dpdk.packet_transport = NULL;

--- a/dpdk/vr_dpdk_packet.c
+++ b/dpdk/vr_dpdk_packet.c
@@ -14,13 +14,11 @@
 
 int dpdk_packet_core_id = -1;
 
-int
-vr_dpdk_packet_tx(void)
+void
+vr_dpdk_packet_tx(struct vr_dpdk_lcore *lcorep)
 {
     int ret;
     uint64_t event = 1;
-    unsigned int lcore_id = rte_lcore_id();
-    struct vr_dpdk_lcore *lcorep = vr_dpdk.lcores[lcore_id];
 
     if (lcorep->lcore_event_sock) {
         ret = vr_usocket_write(lcorep->lcore_event_sock, (unsigned char *)&event,
@@ -30,8 +28,6 @@ vr_dpdk_packet_tx(void)
             lcorep->lcore_event_sock = NULL;
         }
     }
-
-    return 0;
 }
 
 int

--- a/dpdk/vr_dpdk_packet.c
+++ b/dpdk/vr_dpdk_packet.c
@@ -76,17 +76,17 @@ dpdk_packet_socket_close(void)
 int
 dpdk_packet_socket_init(void)
 {
-    int ret, i;
-    unsigned int netlink_lcore_id = rte_lcore_id();
-    unsigned short lcore_count = rte_lcore_count();
+    unsigned lcore_id;
     struct vr_dpdk_lcore *lcorep;
 
     vr_dpdk.packet_transport = (void *)vr_usocket(PACKET, RAW);
     if (!vr_dpdk.packet_transport)
         return -1;
 
-    if (lcore_count == VR_DPDK_MIN_LCORES)
+    if (rte_lcore_count() == VR_DPDK_MIN_LCORES) {
+        RTE_LOG(INFO, VROUTER, "Setting packet socket to non-blocking\n");
         vr_usocket_non_blocking(vr_dpdk.packet_transport);
+    }
 
     if (!vr_dpdk.packet_ring) {
         vr_dpdk.packet_ring = rte_ring_lookup("pkt0_tx");
@@ -94,20 +94,15 @@ dpdk_packet_socket_init(void)
             vr_dpdk.packet_ring = rte_ring_create("pkt0_tx", VR_DPDK_TX_RING_SZ,
                     SOCKET_ID_ANY, 0);
             if (!vr_dpdk.packet_ring) {
-                ret = -ENOMEM;
                 goto error;
             }
         }
     }
 
-    for (i = 0; i < lcore_count; i++) {
-        if (i == netlink_lcore_id)
-            continue;
-
-        lcorep = vr_dpdk.lcores[i];
+    RTE_LCORE_FOREACH_SLAVE(lcore_id) {
+        lcorep = vr_dpdk.lcores[lcore_id];
         lcorep->lcore_event_sock = (void *)vr_usocket(EVENT, RAW);
         if (!lcorep->lcore_event_sock) {
-            ret = -ENOMEM;
             goto error;
         }
 
@@ -116,14 +111,11 @@ dpdk_packet_socket_init(void)
             goto error;
     }
 
-
     return 0;
 
 error:
-    if (vr_dpdk.packet_transport) {
-        vr_usocket_close(vr_dpdk.packet_transport);
-        vr_dpdk.packet_transport = NULL;
-    }
+    vr_usocket_close(vr_dpdk.packet_transport);
+    vr_dpdk.packet_transport = NULL;
 
-    return ret;
+    return -ENOMEM;
 }

--- a/dpdk/vr_dpdk_packet.c
+++ b/dpdk/vr_dpdk_packet.c
@@ -15,12 +15,12 @@
 int dpdk_packet_core_id = -1;
 
 void
-vr_dpdk_packet_tx(struct vr_dpdk_lcore *lcorep)
+vr_dpdk_packet_wakeup(struct vr_dpdk_lcore *lcorep)
 {
     int ret;
     uint64_t event = 1;
 
-    if (lcorep->lcore_event_sock) {
+    if (unlikely(lcorep->lcore_event_sock != NULL)) {
         ret = vr_usocket_write(lcorep->lcore_event_sock, (unsigned char *)&event,
                 sizeof(event));
         if (ret < 0) {

--- a/dpdk/vr_dpdk_ringdev.c
+++ b/dpdk/vr_dpdk_ringdev.c
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2014 Semihalf.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation version 2.
+ *
+ * This program is distributed "as is" WITHOUT ANY WARRANTY of any
+ * kind, whether express or implied; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * vr_dpdk_ringdev.c -- DPDK ring device
+ *
+ */
+#include <stdio.h>
+#include <unistd.h>
+
+#include "vr_dpdk.h"
+
+#include <rte_port_ring.h>
+#include <rte_malloc.h>
+
+/* Allocates a new ring */
+struct rte_ring *
+vr_dpdk_ring_allocate(unsigned host_lcore_id, char *ring_name,
+    unsigned vr_dpdk_tx_ring_sz)
+{
+    int ret;
+    ssize_t ring_size;
+    struct rte_ring *ring;
+
+    ring_size = rte_ring_get_memsize(vr_dpdk_tx_ring_sz);
+    if (ring_size == -EINVAL)
+        return NULL;
+
+    ring = (struct rte_ring *)rte_malloc_socket(ring_name, ring_size,
+        CACHE_LINE_SIZE,  rte_lcore_to_socket_id(host_lcore_id));
+    if (ring == NULL)
+        return NULL;
+
+    /* create single-producer single-consumer ring */
+    ret = rte_ring_init(ring, ring_name, vr_dpdk_tx_ring_sz,
+        RING_F_SP_ENQ | RING_F_SC_DEQ);
+    if (ret < 0) {
+        rte_free(ring);
+        return NULL;
+    }
+
+    return ring;
+}
+
+/* Add the ring to the list of rings to push */
+void
+dpdk_ring_to_push_add(unsigned lcore_id, struct rte_ring *tx_ring,
+    struct vr_dpdk_queue *tx_queue)
+{
+    struct vr_dpdk_lcore *lcore = vr_dpdk.lcores[lcore_id];
+    struct vr_dpdk_ring_to_push *rtp = &lcore->lcore_rings_to_push[0];
+
+    /* find an empty ring to push */
+    while (rtp->rtp_tx_ring) rtp++;
+
+    rtp->rtp_tx_ring = tx_ring;
+    rtp->rtp_tx_queue = tx_queue;
+    rte_wmb();
+    lcore->lcore_nb_rings_to_push++;
+    RTE_VERIFY(lcore->lcore_nb_rings_to_push < VR_DPDK_MAX_RINGS);
+}
+
+/* Remove the ring from the list of rings to push
+ * The function is called by the NetLink lcore only.
+ */
+void
+dpdk_ring_to_push_remove(unsigned lcore_id, struct rte_ring *tx_ring)
+{
+    struct vr_dpdk_lcore *lcore = vr_dpdk.lcores[lcore_id];
+    struct vr_dpdk_ring_to_push *rtp = &lcore->lcore_rings_to_push[0];
+    struct vr_dpdk_ring_to_push *last_rtp;
+
+    /* find the ring to push */
+    while (rtp->rtp_tx_ring != tx_ring) rtp++;
+
+    rtp->rtp_tx_ring = NULL;
+    lcore->lcore_nb_rings_to_push--;
+    RTE_VERIFY(lcore->lcore_nb_rings_to_push < VR_DPDK_MAX_RINGS);
+    rte_wmb();
+    /* copy the last element to the empty spot */
+    last_rtp = &lcore->lcore_rings_to_push[lcore->lcore_nb_rings_to_push];
+    rtp->rtp_tx_queue = last_rtp->rtp_tx_queue;
+    rte_wmb();
+    rtp->rtp_tx_ring = last_rtp->rtp_tx_ring;
+    last_rtp->rtp_tx_ring = NULL;
+    last_rtp->rtp_tx_queue = NULL;
+}
+
+/* Release ring TX queue
+ * The function is called by the NetLink lcore only.
+ */
+static void
+dpdk_ring_tx_queue_release(unsigned lcore_id, struct vr_interface *vif)
+{
+    struct vr_dpdk_lcore *lcore = vr_dpdk.lcores[lcore_id];
+    struct vr_dpdk_queue *tx_queue = &lcore->lcore_tx_queues[vif->vif_idx];
+    struct vr_dpdk_queue_params *tx_queue_params
+                        = &lcore->lcore_tx_queue_params[vif->vif_idx];
+
+    tx_queue->txq_ops.f_tx = NULL;
+    rte_wmb();
+
+    /* remove the ring from the list of rings to push */
+    dpdk_ring_to_push_remove(tx_queue_params->qp_ring.host_lcore_id,
+            tx_queue_params->qp_ring.ring_p);
+
+    rte_free(tx_queue_params->qp_ring.ring_p);
+
+    /* flush and free the queue */
+    if (tx_queue->txq_ops.f_free(tx_queue->q_queue_h)) {
+        RTE_LOG(ERR, VROUTER, "\terror freeing lcore %u ring\n", lcore_id);
+    }
+
+    /* reset the queue */
+    vrouter_put_interface(tx_queue->q_vif);
+    memset(tx_queue, 0, sizeof(*tx_queue));
+    memset(tx_queue_params, 0, sizeof(*tx_queue_params));
+}
+
+/* Init ring TX queue */
+struct vr_dpdk_queue *
+vr_dpdk_ring_tx_queue_init(unsigned lcore_id, struct vr_interface *vif,
+    unsigned host_lcore_id)
+{
+    struct vr_dpdk_lcore *lcore = vr_dpdk.lcores[lcore_id];
+    struct vr_dpdk_lcore *host_lcore = vr_dpdk.lcores[host_lcore_id];
+    const unsigned socket_id = rte_lcore_to_socket_id(lcore_id);
+    uint8_t port_id;
+    unsigned vif_idx = vif->vif_idx;
+    struct vr_dpdk_queue *tx_queue = &lcore->lcore_tx_queues[vif_idx];
+    struct vr_dpdk_queue_params *tx_queue_params
+                = &lcore->lcore_tx_queue_params[vif_idx];
+    struct vr_dpdk_queue *host_tx_queue = &host_lcore->lcore_tx_queues[vif_idx];
+    struct rte_ring *tx_ring;
+    char ring_name[RTE_RING_NAMESIZE];
+    int ret;
+
+
+    if (vif->vif_type == VIF_TYPE_PHYSICAL) {
+        port_id = (((struct vr_dpdk_ethdev *)(vif->vif_os))->ethdev_port_id);
+    } else {
+        port_id = vif->vif_os_idx;
+    }
+
+    /* init queue */
+    tx_queue->txq_ops = rte_port_ring_writer_ops;
+    tx_queue->q_queue_h = NULL;
+    tx_queue->q_vif = vrouter_get_interface(vif->vif_rid, vif_idx);
+
+    ret = snprintf(ring_name, sizeof(ring_name), "vr_dpdk_ring_%u_%u_%u",
+        host_lcore_id, vif_idx, lcore_id);
+    if (ret >= sizeof(ring_name))
+        goto error;
+
+    /* allocate a ring on the host lcore */
+    tx_ring = vr_dpdk_ring_allocate(host_lcore_id, ring_name, VR_DPDK_TX_RING_SZ);
+    if (tx_ring == NULL)
+        goto error;
+
+    /* add the ring to the list of rings to push */
+    dpdk_ring_to_push_add(host_lcore_id, tx_ring, host_tx_queue);
+
+    /* create the queue */
+    struct rte_port_ring_writer_params writer_params = {
+        .ring = tx_ring,
+        .tx_burst_sz = VR_DPDK_RING_TX_BURST_SZ,
+    };
+    tx_queue->q_queue_h = tx_queue->txq_ops.f_create(&writer_params,
+                                                        socket_id);
+    if (tx_queue->q_queue_h == NULL)
+        goto error;
+
+    /* store queue params */
+    tx_queue_params->qp_release_op = &dpdk_ring_tx_queue_release;
+    tx_queue_params->qp_ring.ring_p = tx_ring;
+    tx_queue_params->qp_ring.host_lcore_id = host_lcore_id;
+
+    return tx_queue;
+
+error:
+    RTE_LOG(ERR, VROUTER, "\terror initializing ring TX queue for device %"
+        PRIu8 "\n", port_id);
+    return NULL;
+}
+
+/* Init ring RX queue */
+struct vr_dpdk_queue *
+vr_dpdk_ring_rx_queue_init(unsigned lcore_id, struct vr_interface *vif,
+    unsigned host_lcore_id)
+{
+    RTE_LOG(ERR, VROUTER, "%s: not implemented\n", __func__);
+
+    return NULL;
+}

--- a/dpdk/vr_dpdk_usocket.c
+++ b/dpdk/vr_dpdk_usocket.c
@@ -1,0 +1,1113 @@
+/*
+ * vr_dpdk_usocket.c -- library to deal with packet0 and netlink tcp/unix
+ * sockets
+ *
+ * Copyright(c) 2014, Juniper Networks Inc.
+ * All rights reserved
+ */
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <stdbool.h>
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <sys/eventfd.h>
+
+#include <urcu-qsbr.h>
+
+#include <netinet/in.h>
+
+#include <linux/netlink.h>
+
+#include "vr_queue.h"
+#include "vr_dpdk_usocket.h"
+#include "vr_message.h"
+#include "vr_dpdk.h"
+
+#define INFINITE_TIMEOUT    -1
+
+extern void dpdk_burst_rx(unsigned int, struct rte_mbuf *[],
+                struct vr_interface *, const char *, unsigned int);
+extern struct nlmsghdr *dpdk_nl_message_hdr(struct vr_message *);
+extern unsigned int dpdk_nl_message_len(struct vr_message *);
+
+static int vr_usocket_accept(struct vr_usocket *);
+static int vr_usocket_connect(struct vr_usocket *);
+static int vr_usocket_bind(struct vr_usocket *);
+static int usock_write(struct vr_usocket *);
+static int usock_read_init(struct vr_usocket *);
+
+/*
+ * mark the error in socket for somebody to process/see
+ */
+static void
+usock_set_error(struct vr_usocket *usockp, int error)
+{
+    usockp->usock_error = error;
+    usockp->usock_errno = errno;
+
+    return;
+}
+
+/*
+ * free the poll descriptor array, if it was allocated
+ */
+static void
+usock_deinit_poll(struct vr_usocket *usockp)
+{
+    if (!usockp)
+        return;
+
+    if (usockp->usock_pfds) {
+        vr_free(usockp->usock_pfds);
+        usockp->usock_pfds = NULL;
+    }
+
+    return;
+}
+
+/*
+ * for both netlink and packet protocol sockets, we will need to poll. in case
+ * of netlink, the poll in on tcp sockets to accept a connection (from agent,
+ * utilities etc.:). for packet socket, the poll is on unix socket to receive
+ * packets from agent and to be passed to vrouter. packet sockets also will
+ * have an event usocket to dequeue packets from the pkt0_mbuf_ring, where
+ * packets to be trapped will be enqueued.
+ *
+ * alloc the poll array
+ */
+static int
+usock_init_poll(struct vr_usocket *usockp)
+{
+    unsigned int i;
+    unsigned int proto;
+
+    if (!usockp)
+        return -EINVAL;
+
+    proto = usockp->usock_proto;
+    if ((proto != NETLINK) && (proto != PACKET)) {
+        usock_set_error(usockp, -EINVAL);
+        goto error_return;
+    }
+
+    if (!usockp->usock_max_cfds) {
+        usock_set_error(usockp, -EINVAL);
+        goto error_return;
+    }
+
+    if (!usockp->usock_pfds) {
+        usockp->usock_pfds = vr_zalloc(sizeof(struct pollfd) *
+                usockp->usock_max_cfds + 1);
+        if (!usockp->usock_pfds) {
+            usock_set_error(usockp, -ENOMEM);
+            goto error_return;
+        }
+
+        for (i = 1; i <= usockp->usock_max_cfds; i++) {
+            usockp->usock_pfds[i].fd = -1;
+        }
+    }
+
+    return 0;
+
+error_return:
+    return usockp->usock_error;
+}
+
+/*
+ * bind a child socket to the parent. binding in this context means adding
+ * a child usocket to parent poll list. an example where this will be required
+ * is when one has created an event usocket. An event usocket by itself cannot
+ * do anything useful in the context of dpdk vrouter application. Hence it needs
+ * to be bound to the parent socket that does something useful, in this case
+ * the packet socket. Another example is that of netlink socket. when thexi
+ * netlink socket accepts new connection and the new connected socket has to be
+ * polled, in which case we will need to bind it to the parent socket poll list
+ */
+static int
+usock_bind_usockets(struct vr_usocket *parent, struct vr_usocket *child)
+{
+    unsigned int i;
+    int ret;
+    struct vr_usocket *child_pair;
+
+    if (parent->usock_state == LIMITED)
+        return -ENOSPC;
+
+    if (child->usock_proto == EVENT) {
+        child_pair = vr_usocket(EVENT, RAW);
+        if (!child_pair)
+            return -ENOMEM;
+
+        close(child->usock_fd);
+        child->usock_fd = child_pair->usock_fd;
+        child = child_pair;
+    }
+
+    ret = usock_init_poll(parent);
+    if (ret)
+        return ret;
+
+    if (!parent->usock_children) {
+        parent->usock_children = vr_zalloc(sizeof(struct vr_usocket *) *
+                USOCK_MAX_CHILD_FDS + 1);
+        if (!parent->usock_children) {
+            usock_set_error(parent, -ENOMEM);
+            return -ENOMEM;
+        }
+    }
+
+    child->usock_parent = parent;
+    parent->usock_cfds++;
+    if (parent->usock_cfds == USOCK_MAX_CHILD_FDS)
+        parent->usock_state = LIMITED;
+
+    for (i = 1; i <= parent->usock_max_cfds; i++) {
+        if (!parent->usock_children[i]) {
+            parent->usock_children[i] = child;
+            parent->usock_pfds[i].fd = child->usock_fd;
+            parent->usock_pfds[i].events = POLLIN;
+            child->usock_child_index = i;
+            break;
+        }
+    }
+
+    if (child->usock_proto == EVENT)
+        child->usock_state = READING_DATA;
+
+    usock_read_init(child);
+
+    return 0;
+}
+
+int
+vr_usocket_bind_usockets(void *usock1, void *usock2)
+{
+    struct vr_usocket *parent = (struct vr_usocket *)usock1;
+    struct vr_usocket *child = (struct vr_usocket *)usock2;
+
+    return usock_bind_usockets(parent, child);
+}
+
+static int
+usock_clone(struct vr_usocket *parent, int cfd)
+{
+    struct vr_usocket *child;
+
+    child = vr_zalloc(sizeof(struct vr_usocket));
+    if (!child) {
+        usock_set_error(parent, -ENOMEM);
+        goto error_return;
+    }
+
+    child->usock_rx_buf = vr_malloc(USOCK_RX_BUF_LEN);
+    if (!child->usock_rx_buf) {
+        usock_set_error(parent, -ENOMEM);
+        goto error_return;
+    }
+    child->usock_buf_len = USOCK_RX_BUF_LEN;
+
+    child->usock_type = parent->usock_type;
+    child->usock_proto = parent->usock_proto;
+    child->usock_fd = cfd;
+
+    if (usock_bind_usockets(parent, child))
+        goto error_return;
+
+    return 0;
+
+error_return:
+    if (child) {
+        if (child->usock_rx_buf)
+            vr_free(child->usock_rx_buf);
+        vr_free(child);
+    }
+
+    return parent->usock_error;
+}
+
+
+static void
+usock_unbind(struct vr_usocket *child)
+{
+    struct vr_usocket *parent;
+
+    if (!child)
+        return;
+
+    parent = child->usock_parent;
+    if (!parent)
+        return;
+
+    parent->usock_children[child->usock_child_index] = NULL;
+    if (parent->usock_pfds)
+        parent->usock_pfds[child->usock_child_index].fd = -1;
+
+    parent->usock_disconnects++;
+    parent->usock_cfds--;
+
+    child->usock_parent = NULL;
+
+    return;
+}
+
+static void
+usock_close(struct vr_usocket *usockp)
+{
+    int i;
+    struct vr_usocket *parent;
+
+    RTE_SET_USED(parent);
+
+    if (!usockp)
+        return;
+
+    usock_unbind(usockp);
+    usock_deinit_poll(usockp);
+
+    for (i = 0; i < usockp->usock_cfds; i++) {
+        usock_close(usockp->usock_children[i]);
+    }
+
+    close(usockp->usock_fd);
+
+    if (!usockp->usock_mbuf_pool && usockp->usock_rx_buf) {
+        vr_free(usockp->usock_rx_buf);
+        usockp->usock_rx_buf = NULL;
+    }
+
+    if (usockp->usock_iovec) {
+        vr_free(usockp->usock_iovec);
+        usockp->usock_iovec = NULL;
+    }
+
+    if (usockp->usock_mbuf_pool) {
+        /* no api to destroy a pool */
+    }
+
+    if (usockp->usock_proto == PACKET)
+        unlink(VR_PACKET_UNIX_FILE);
+
+    usockp->usock_io_in_progress = 0;
+
+    vr_free(usockp);
+
+    return;
+}
+
+static int
+__usock_write(struct vr_usocket *usockp)
+{
+    int ret;
+    unsigned int len;
+    unsigned char *buf;
+    struct vr_usocket *parent = NULL;
+
+    if (usockp->usock_proto != EVENT) {
+        parent = usockp->usock_parent;
+        if (!parent)
+            return -1;
+    }
+
+    buf = usockp->usock_tx_buf;
+    if (!buf || !usockp->usock_write_len)
+        return 0;
+
+    len = usockp->usock_write_len;
+
+    buf += usockp->usock_write_offset;
+    len -= usockp->usock_write_offset;
+
+retry_write:
+    ret = write(usockp->usock_fd, buf, len);
+    if (ret > 0) {
+        usockp->usock_write_offset += ret;
+        if (usockp->usock_write_offset == usockp->usock_write_len) {
+            /* remove from output poll */
+            if (parent)
+                parent->usock_pfds[usockp->usock_child_index].events = POLLIN;
+            usockp->usock_tx_buf = NULL;
+        } else {
+            if (parent)
+                parent->usock_pfds[usockp->usock_child_index].events = POLLOUT;
+        }
+    } else if (ret < 0) {
+        usock_set_error(usockp, ret);
+
+        if (errno == EINTR)
+            goto retry_write;
+
+        if ((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
+            if (parent) {
+                parent->usock_pfds[usockp->usock_child_index].events = POLLOUT;
+                return 0;
+            }
+        }
+        usockp->usock_tx_buf = NULL;
+    }
+
+    return ret;
+}
+
+static void
+usock_netlink_write_responses(struct vr_usocket *usockp)
+{
+    int ret;
+    struct vr_message *resp;
+
+    while ((resp =
+                (struct vr_message *)vr_queue_dequeue(&usockp->usock_nl_responses))) {
+        usockp->usock_tx_buf = (unsigned char *)dpdk_nl_message_hdr(resp);
+        usockp->usock_write_len = dpdk_nl_message_len(resp);
+        usockp->usock_write_offset = 0;
+        ret = __usock_write(usockp);
+        if ((ret < 0) || (ret == usockp->usock_write_len)) {
+            vr_message_free(resp);
+        } else {
+            break;
+        }
+    }
+
+    return;
+}
+
+
+static int
+usock_mbuf_write(struct vr_usocket *usockp, struct rte_mbuf *mbuf)
+{
+    unsigned int i, pkt_len;
+    struct msghdr mhdr;
+    struct rte_mbuf *m;
+    struct iovec *iov;
+
+    if (!mbuf)
+        return 0;
+
+    pkt_len = rte_pktmbuf_pkt_len(mbuf);
+    if (!pkt_len)
+        return 0;
+
+    iov = usockp->usock_iovec;
+
+    m = mbuf;
+    for (i = 0; (m && (i < PKT0_MAX_IOV_LEN)); i++) {
+        iov->iov_base = rte_pktmbuf_mtod(m, unsigned char *);
+        iov->iov_len = rte_pktmbuf_data_len(m);
+        m = m->pkt.next;
+        iov++;
+    }
+
+    if ((i == PKT0_MAX_IOV_LEN) && m)
+        usockp->usock_pkt_truncated++;
+
+    mhdr.msg_name = NULL;
+    mhdr.msg_namelen = 0;
+    mhdr.msg_iov = usockp->usock_iovec;
+    mhdr.msg_iovlen = i;
+    mhdr.msg_control = NULL;
+    mhdr.msg_controllen = 0;
+    mhdr.msg_flags = 0;
+
+    return sendmsg(usockp->usock_fd, &mhdr, MSG_DONTWAIT);
+}
+
+static void
+vr_dpdk_pkt0_receive(struct vr_usocket *usockp)
+{
+    struct rte_pktmbuf *pmbuf;
+    struct vr_packet *pkt;
+    const unsigned lcore_id = rte_lcore_id();
+    struct vr_dpdk_lcore *lcore = vr_dpdk.lcores[lcore_id];
+
+    if (usockp->usock_vif) {
+        pmbuf = &usockp->usock_mbuf->pkt;
+        pmbuf->data = usockp->usock_rx_buf;
+        pmbuf->data_len = usockp->usock_read_len;
+        pmbuf->pkt_len = usockp->usock_read_len;
+        /* convert mbuf to vr_packet */
+        pkt = vr_dpdk_packet_get(usockp->usock_mbuf, usockp->usock_vif);
+        /* send the packet to vRouter */
+        vr_dpdk_packets_vroute(usockp->usock_vif, &pkt, 1);
+        /* flush pkt0 TX queues immediately */
+        vr_dpdk_lcore_flush(lcore);
+
+        rcu_quiescent_state();
+    } else {
+        rte_pktmbuf_free(usockp->usock_mbuf);
+    }
+
+    usockp->usock_mbuf = NULL;
+    usockp->usock_rx_buf = NULL;
+    usockp->usock_buf_len = 0;
+
+    return;
+}
+
+static struct rte_mbuf *
+vr_dpdk_drain_pkt0_ring(struct vr_usocket *usockp)
+{
+    int ret;
+    void *objp;
+
+    ret = rte_ring_dequeue(vr_dpdk.packet_ring, &objp);
+    if (ret)
+        return NULL;
+
+    return (struct rte_mbuf *)objp;
+}
+
+static int
+usock_read_done(struct vr_usocket *usockp)
+{
+    struct rte_mbuf *mbuf;
+
+    if (usockp->usock_state == READING_FAULTY_DATA)
+        return 0;
+
+    switch (usockp->usock_proto) {
+    case PACKET:
+        vr_dpdk_pkt0_receive(usockp);
+        break;
+
+    case EVENT:
+        while ((mbuf = vr_dpdk_drain_pkt0_ring(usockp))) {
+            usock_mbuf_write(usockp->usock_parent, mbuf);
+        }
+        break;
+
+    case NETLINK:
+        dpdk_netlink_receive(usockp, usockp->usock_rx_buf,
+                usockp->usock_read_len);
+        break;
+
+    default:
+        break;
+    }
+
+    return 0;
+}
+
+static int
+usock_read_init(struct vr_usocket *usockp)
+{
+    usockp->usock_read_offset = 0;
+
+    switch (usockp->usock_proto) {
+    case NETLINK:
+        if (usockp->usock_parent) {
+            usockp->usock_read_len = NLMSG_HDRLEN;
+            usockp->usock_state = READING_HEADER;
+        }
+        break;
+
+    case EVENT:
+        usockp->usock_read_len = USOCK_EVENT_BUF_LEN;
+        usockp->usock_state = READING_DATA;
+        break;
+
+    case PACKET:
+        if (usockp->usock_mbuf)
+            return -EINVAL;
+
+        usockp->usock_mbuf = rte_pktmbuf_alloc(usockp->usock_mbuf_pool);
+        if (!usockp->usock_mbuf)
+            return -ENOMEM;
+
+        usockp->usock_rx_buf = rte_pktmbuf_mtod(usockp->usock_mbuf,
+                char *);
+        usockp->usock_buf_len = PKT0_MBUF_PACKET_SIZE;
+        usockp->usock_read_len = PKT0_MBUF_PACKET_SIZE;
+        usockp->usock_state = READING_DATA;
+        break;
+
+    default:
+        break;
+    }
+
+    return 0;
+}
+
+static int
+__usock_read(struct vr_usocket *usockp)
+{
+    int ret;
+
+    unsigned int offset = usockp->usock_read_offset;
+    unsigned int len = usockp->usock_read_len;
+    unsigned int toread = len - offset;
+
+    struct nlmsghdr *nlh;
+    unsigned int proto = usockp->usock_proto;
+    char *buf = usockp->usock_rx_buf;
+
+    if (toread > usockp->usock_buf_len) {
+        toread = usockp->usock_buf_len - offset;
+    }
+
+retry_read:
+    ret = read(usockp->usock_fd, buf + offset, toread);
+    if (ret <= 0) {
+        if (!ret)
+            return -1;
+
+        if (errno == EINTR)
+            goto retry_read;
+
+        if ((errno == EAGAIN) ||
+                (errno == EWOULDBLOCK))
+            return 0;
+
+        return ret;
+    }
+
+    offset += ret;
+    usockp->usock_read_offset = offset;
+
+    if (proto == NETLINK) {
+        if (usockp->usock_state == READING_HEADER) {
+            if (usockp->usock_read_offset == usockp->usock_read_len) {
+                usockp->usock_state = READING_DATA;
+                nlh = (struct nlmsghdr *)(usockp->usock_rx_buf);
+                usockp->usock_read_len = nlh->nlmsg_len;
+            }
+        }
+
+        if (usockp->usock_buf_len < usockp->usock_read_len) {
+            usockp->usock_rx_buf = vr_malloc(usockp->usock_read_len);
+            if (!usockp->usock_rx_buf) {
+                /* bad, but let's recover */
+                usockp->usock_rx_buf = buf;
+                usockp->usock_read_len -= usockp->usock_read_offset;
+                usockp->usock_read_offset = 0;
+                usockp->usock_state = READING_FAULTY_DATA;
+            } else {
+                memcpy(usockp->usock_rx_buf, buf, usockp->usock_read_offset);
+                vr_free(buf);
+                usockp->usock_buf_len = usockp->usock_read_len;
+                buf = usockp->usock_rx_buf;
+            }
+        }
+    } else if (proto == PACKET) {
+        usockp->usock_read_len = ret;
+    }
+
+    return ret;
+}
+
+
+static struct vr_usocket *
+usock_alloc(unsigned short proto, unsigned short type)
+{
+    int sock_fd = -1, domain;
+    int error = 0, flags;
+    unsigned int buf_len;
+    struct vr_usocket *usockp = NULL, *child;
+    bool is_socket = true;
+    unsigned short sock_type;
+
+    RTE_SET_USED(child);
+
+    switch (type) {
+    case TCP:
+        domain = AF_INET;
+        sock_type = SOCK_STREAM;
+        break;
+
+    case UNIX:
+    case RAW:
+        domain = AF_UNIX;
+        sock_type = SOCK_DGRAM;
+        break;
+
+    default:
+        return NULL;
+    }
+
+    if (proto == EVENT) {
+        is_socket = false;
+        sock_fd = eventfd(0, 0);
+        if (sock_fd < 0)
+            return NULL;
+    }
+
+    if (is_socket) {
+        sock_fd = socket(domain, sock_type, 0);
+        if (sock_fd < 0)
+            return NULL;
+    }
+
+    usockp = vr_zalloc(sizeof(*usockp));
+    if (!usockp)
+        goto error_exit;
+
+    usockp->usock_type = type;
+    usockp->usock_proto = proto;
+    usockp->usock_fd = sock_fd;
+    usockp->usock_state = INITED;
+
+    if (is_socket) {
+        error = vr_usocket_bind(usockp);
+        if (error < 0)
+            goto error_exit;
+
+        if (usockp->usock_proto == PACKET) {
+            error = vr_usocket_connect(usockp);
+            if (error < 0)
+                goto error_exit;
+        }
+    }
+
+    switch (proto) {
+    case NETLINK:
+        usockp->usock_max_cfds = USOCK_MAX_CHILD_FDS;
+        buf_len = 0;
+        break;
+
+    case PACKET:
+        usockp->usock_max_cfds = USOCK_MAX_CHILD_FDS;
+        buf_len = 0;
+        break;
+
+    case EVENT:
+        buf_len = USOCK_EVENT_BUF_LEN;
+        break;
+
+    default:
+        buf_len = 0;
+        break;
+    }
+
+    if (buf_len) {
+        usockp->usock_rx_buf = vr_zalloc(buf_len);
+        if (!usockp->usock_rx_buf)
+            goto error_exit;
+
+        usockp->usock_buf_len = buf_len;
+        usock_read_init(usockp);
+    }
+
+    if (proto == PACKET) {
+        usockp->usock_mbuf_pool = rte_mempool_lookup("pkt0_mbuf_pool");
+        if (!usockp->usock_mbuf_pool) {
+            usockp->usock_mbuf_pool = rte_mempool_create("pkt0_mbuf_pool",
+                    PKT0_MBUF_POOL_SIZE, PKT0_MBUF_PACKET_SIZE,
+                    PKT0_MBUF_POOL_CACHE_SZ, sizeof(struct rte_pktmbuf_pool_private),
+                    rte_pktmbuf_pool_init, NULL, vr_dpdk_pktmbuf_init, NULL,
+                    rte_socket_id(), 0);
+            if (!usockp->usock_mbuf_pool)
+                goto error_exit;
+        }
+
+        usockp->usock_iovec = vr_zalloc(sizeof(struct iovec) *
+                PKT0_MAX_IOV_LEN);
+        if (!usockp->usock_iovec)
+            goto error_exit;
+
+        usock_read_init(usockp);
+    }
+
+    flags = fcntl(usockp->usock_fd, F_GETFL);
+    if (flags == -1)
+        goto error_exit;
+
+    error = fcntl(usockp->usock_fd, F_SETFL, flags | O_NONBLOCK);
+    if (error == -1)
+        goto error_exit;
+
+    usockp->usock_poll_block = 1;
+
+    return usockp;
+
+error_exit:
+    if (sock_fd >= 0) {
+        close(sock_fd);
+        sock_fd = -1;
+    }
+
+    usock_close(usockp);
+    usockp = NULL;
+
+    return usockp;
+}
+
+/*
+ * currently defined protocols are netlink and packet.
+ * for packet, only raw socket type is accepted
+ * for netlink, both tcp and unix socket types are accepted
+ */
+static bool
+valid_usock(int proto, int type)
+{
+    if ((proto != PACKET) &&
+            (proto != NETLINK) &&
+            (proto != EVENT))
+        return -EINVAL;
+
+    if (((proto == PACKET) || (proto == EVENT)) && (type != RAW)) {
+        return -EINVAL;
+    } else {
+        if (type != TCP && type != UNIX)
+            return -EINVAL;
+    }
+
+    return true;
+}
+
+void
+vr_usocket_detach_vif(void *usockp)
+{
+    ((struct vr_usocket *)usockp)->usock_vif = NULL;
+    return;
+}
+
+void
+vr_usocket_attach_vif(void *usockp, struct vr_interface *vif)
+{
+    if (!vif)
+        return;
+
+    ((struct vr_usocket *)usockp)->usock_vif = vif;
+    return;
+}
+
+void
+vr_usocket_non_blocking(struct vr_usocket *usockp)
+{
+    usockp->usock_poll_block = 0;
+    return;
+}
+
+int
+vr_usocket_write(struct vr_usocket *usockp, unsigned char *buf,
+        unsigned int len)
+{
+    if (usockp->usock_tx_buf)
+        return -1;
+
+    usockp->usock_tx_buf = buf;
+    usockp->usock_write_offset = 0;
+    usockp->usock_write_len = len;
+
+    return __usock_write(usockp);
+}
+
+int
+vr_usocket_message_write(struct vr_usocket *usockp,
+        struct vr_message *message)
+{
+    int ret;
+    unsigned int len;
+    unsigned char *buf;
+
+    if ((usockp->usock_proto != NETLINK) && (usockp->usock_type != TCP))
+        return -EINVAL;
+
+    if (usockp->usock_tx_buf || !vr_queue_empty(&usockp->usock_nl_responses)) {
+        vr_queue_enqueue(&usockp->usock_nl_responses,
+                &message->vr_message_queue);
+        return 0;
+    }
+
+    buf = (unsigned char *)dpdk_nl_message_hdr(message);
+    len = dpdk_nl_message_len(message);
+    ret = vr_usocket_write(usockp, buf, len);
+    if (ret == len) {
+        vr_message_free(message);
+    }
+
+    return ret;
+}
+
+static int
+vr_usocket_read(struct vr_usocket *usockp)
+{
+    int ret;
+
+    if (!usockp || usockp->usock_fd < 0)
+        return -1;
+
+    switch (usockp->usock_state) {
+    case LISTENING:
+    case LIMITED:
+        ret = vr_usocket_accept(usockp);
+        if (ret < 0)
+            return ret;
+
+        break;
+
+    case READING_HEADER:
+    case READING_DATA:
+    case READING_FAULTY_DATA:
+        ret = __usock_read(usockp);
+        if (ret < 0) {
+            usock_close(usockp);
+            return ret;
+        }
+
+        if (usockp->usock_read_offset == usockp->usock_read_len) {
+            usock_read_done(usockp);
+            /* we have the complete message */
+            usock_read_init(usockp);
+        }
+
+        break;
+
+    default:
+        return -1;
+    }
+
+    return ret;
+}
+
+static int
+vr_usocket_connect(struct vr_usocket *usockp)
+{
+    struct sockaddr_un sun;
+
+    if (usockp->usock_proto != PACKET)
+        return -EINVAL;
+
+    sun.sun_family = AF_UNIX;
+    bzero(sun.sun_path, sizeof(sun.sun_path));
+    strncpy(sun.sun_path, VR_PACKET_AGENT_UNIX_FILE, sizeof(sun.sun_path) - 1);
+
+    return connect(usockp->usock_fd, (struct sockaddr *)&sun, sizeof(sun));
+}
+
+static int
+vr_usocket_accept(struct vr_usocket *usockp)
+{
+    int ret;
+
+    ret = accept(usockp->usock_fd, NULL, NULL);
+    if (ret < 0) {
+        usock_set_error(usockp, ret);
+        return ret;
+    }
+
+    if ((usockp->usock_state == LIMITED) ||
+            (usock_clone(usockp, ret)))
+        close(ret);
+
+    return 0;
+}
+
+static int
+vr_usocket_bind(struct vr_usocket *usockp)
+{
+    int error = 0;
+    struct sockaddr_in sin;
+    struct sockaddr_un sun;
+    struct sockaddr *addr = NULL;
+    socklen_t addrlen = 0;
+    int optval;
+    bool server;
+
+    optval = 1;
+    if (setsockopt(usockp->usock_fd, SOL_SOCKET, SO_REUSEADDR, &optval,
+                sizeof(optval)))
+        return -errno;
+
+    switch (usockp->usock_type) {
+    case TCP:
+        sin.sin_family = AF_INET;
+        sin.sin_port = htons(VR_NETLINK_TCP_PORT);
+        sin.sin_addr.s_addr = INADDR_ANY;
+        addr = (struct sockaddr *)&sin;
+        addrlen = sizeof(sin);
+        server = true;
+
+        break;
+
+    case UNIX:
+        sun.sun_family = AF_UNIX;
+        bzero(sun.sun_path, sizeof(sun.sun_path));
+        strncpy(sun.sun_path, VR_NETLINK_UNIX_FILE, sizeof(sun.sun_path) - 1);
+        addr = (struct sockaddr *)&sun;
+        addrlen = sizeof(sun);
+        server = true;
+
+        break;
+
+    case RAW:
+        unlink(VR_PACKET_UNIX_FILE);
+        sun.sun_family = AF_UNIX;
+        bzero(sun.sun_path, sizeof(sun.sun_path));
+        strncpy(sun.sun_path, VR_PACKET_UNIX_FILE, sizeof(sun.sun_path) - 1);
+        addr = (struct sockaddr *)&sun;
+        addrlen = sizeof(sun);
+        server = false;
+
+        break;
+
+    default:
+        return -EINVAL;
+    }
+
+    error = bind(usockp->usock_fd, addr, addrlen);
+    if (error < 0)
+        return error;
+
+    if (server) {
+        error = listen(usockp->usock_fd, 1);
+        if (error < 0)
+            return error;
+        usockp->usock_state = LISTENING;
+    }
+
+    return 0;
+}
+
+void
+vr_usocket_close(void *sock)
+{
+    struct vr_usocket *usockp = (struct vr_usocket *)sock;
+
+    if (usockp->usock_io_in_progress) {
+        usockp->usock_should_close = 1;
+        return;
+    }
+
+    usock_close(usockp);
+    return;
+}
+
+/*
+ * create a usocket which is of type (TCP/UNIX/RAW). the messages
+ * read in those sockets will follow protocol 'proto'. protocol is
+ * netlink, packet or event
+ */
+void *
+vr_usocket(int proto, int type)
+{
+    struct vr_usocket *usockp = NULL;
+
+    RTE_SET_USED(usockp);
+
+    if (!valid_usock(proto, type))
+        return NULL;
+
+    return (void *)usock_alloc(proto, type);
+}
+
+static int
+usock_write(struct vr_usocket *usockp)
+{
+    int ret;
+
+    if (!usockp || usockp->usock_fd < 0)
+        return 0;
+
+    ret = __usock_write(usockp);
+    if (ret < 0) {
+        usock_close(usockp);
+        return ret;
+    }
+
+    if (usockp->usock_proto == NETLINK) {
+        if (usockp->usock_write_offset == usockp->usock_write_len) {
+            usock_netlink_write_responses(usockp);
+        }
+    }
+
+    return 0;
+}
+
+
+/*
+ * start io on socket
+ */
+int
+vr_usocket_io(void *transport)
+{
+    int ret, i, processed;
+    int timeout;
+    struct pollfd *pfd;
+    struct vr_usocket *usockp = (struct vr_usocket *)transport;
+    struct vr_dpdk_lcore *lcore = vr_dpdk.lcores[rte_lcore_id()];
+
+    if (!usockp)
+        return -1;
+
+    if ((ret = usock_init_poll(usockp)))
+        goto return_from_io;
+
+    pfd = &usockp->usock_pfds[0];
+    pfd->fd = usockp->usock_fd;
+    pfd->events = POLLIN;
+
+    usockp->usock_io_in_progress = 1;
+
+    timeout = usockp->usock_poll_block ? INFINITE_TIMEOUT : 0;
+    while (1) {
+
+        if (usockp->usock_should_close) {
+            usock_close(usockp);
+            return -1;
+        }
+
+        rcu_thread_offline();
+
+        /* handle an IPC command */
+        if (unlikely(vr_dpdk_lcore_cmd_handle(lcore)))
+            break;
+
+        ret = poll(usockp->usock_pfds, usockp->usock_max_cfds,
+                timeout);
+        if (ret < 0) {
+            usock_set_error(usockp, ret);
+            if (errno == EINTR) {
+                continue;
+            }
+
+            /* all other errors are fatal */
+            goto return_from_io;
+        }
+
+        processed = 0;
+        pfd = usockp->usock_pfds;
+        for (i = 0; (i < usockp->usock_max_cfds) && (processed <= ret);
+                i++, pfd++) {
+            if ((pfd->fd >= 0)) {
+                if (pfd->revents & POLLIN) {
+                    if (i == 0) {
+                        ret = vr_usocket_read(usockp);
+                        if (ret < 0)
+                            return ret;
+                    } else {
+                        vr_usocket_read(usockp->usock_children[i]);
+                    }
+                }
+
+                if (pfd->revents & POLLOUT) {
+                    usock_write(usockp->usock_children[i]);
+                }
+
+                if (pfd->revents & POLLHUP) {
+                    if (i) {
+                        usock_close(usockp->usock_children[i]);
+                    } else {
+                        break;
+                    }
+                }
+
+                if (pfd->revents)
+                    processed++;
+            }
+        }
+
+        if (!timeout)
+            return 0;
+    }
+
+return_from_io:
+    usockp->usock_io_in_progress = 0;
+    usock_deinit_poll(usockp);
+
+    return ret;
+}
+

--- a/dpdk/vr_dpdk_usocket.c
+++ b/dpdk/vr_dpdk_usocket.c
@@ -932,6 +932,7 @@ vr_usocket_bind(struct vr_usocket *usockp)
         addrlen = sizeof(sun);
         server = true;
         mkdir(VR_SOCKET_DIR, VR_SOCKET_DIR_MODE);
+        unlink(sun.sun_path);
 
         break;
 

--- a/dpdk/vr_dpdk_usocket.c
+++ b/dpdk/vr_dpdk_usocket.c
@@ -975,6 +975,9 @@ vr_usocket_close(void *sock)
 {
     struct vr_usocket *usockp = (struct vr_usocket *)sock;
 
+    if (usockp == NULL)
+        return;
+
     if (usockp->usock_io_in_progress) {
         usockp->usock_should_close = 1;
         return;

--- a/dpdk/vr_dpdk_usocket.c
+++ b/dpdk/vr_dpdk_usocket.c
@@ -1063,20 +1063,22 @@ vr_usocket_io(void *transport)
 
         rcu_thread_offline();
 
-        /* handle an IPC command */
+        /* TODO: handle an IPC command only for pkt0 thread
+         * and just check the stop flag for the rest
+         */
         if (unlikely(vr_dpdk_lcore_cmd_handle(lcore)))
             break;
+//        if (unlikely(vr_dpdk_is_stop_flag_set()))
+//            break;
 
         ret = poll(usockp->usock_pfds, usockp->usock_max_cfds,
                 timeout);
+
         if (ret < 0) {
             usock_set_error(usockp, ret);
-            if (errno == EINTR) {
-                continue;
-            }
-
             /* all other errors are fatal */
-            goto return_from_io;
+            if (errno != EINTR)
+                goto return_from_io;
         }
 
         processed = 0;

--- a/dpdk/vr_dpdk_usocket.c
+++ b/dpdk/vr_dpdk_usocket.c
@@ -879,7 +879,8 @@ vr_usocket_connect(struct vr_usocket *usockp)
     memset(sun.sun_path, 0, sizeof(sun.sun_path));
     strncpy(sun.sun_path, VR_PACKET_AGENT_UNIX_FILE, sizeof(sun.sun_path) - 1);
 
-    return connect(usockp->usock_fd, (struct sockaddr *)&sun, sizeof(sun));
+    return vr_dpdk_retry_connect(usockp->usock_fd, (struct sockaddr *)&sun,
+                                        sizeof(sun));
 }
 
 static int

--- a/dpdk/vr_dpdk_usocket.c
+++ b/dpdk/vr_dpdk_usocket.c
@@ -588,6 +588,8 @@ retry_read:
                 (errno == EWOULDBLOCK))
             return 0;
 
+        RTE_LOG(ERR, USOCK, "Error reading FD %d: %s (%d)\n",
+                usockp->usock_fd, strerror(errno), errno);
         return ret;
     }
 

--- a/dpdk/vr_dpdk_usocket.c
+++ b/dpdk/vr_dpdk_usocket.c
@@ -11,6 +11,7 @@
 #include <poll.h>
 #include <stdbool.h>
 
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/un.h>
@@ -930,17 +931,19 @@ vr_usocket_bind(struct vr_usocket *usockp)
         addr = (struct sockaddr *)&sun;
         addrlen = sizeof(sun);
         server = true;
+        mkdir(VR_SOCKET_DIR, VR_SOCKET_DIR_MODE);
 
         break;
 
     case RAW:
-        unlink(VR_PACKET_UNIX_FILE);
         sun.sun_family = AF_UNIX;
         bzero(sun.sun_path, sizeof(sun.sun_path));
         strncpy(sun.sun_path, VR_PACKET_UNIX_FILE, sizeof(sun.sun_path) - 1);
         addr = (struct sockaddr *)&sun;
         addrlen = sizeof(sun);
         server = false;
+        mkdir(VR_SOCKET_DIR, VR_SOCKET_DIR_MODE);
+        unlink(sun.sun_path);
 
         break;
 

--- a/dpdk/vr_dpdk_usocket.c
+++ b/dpdk/vr_dpdk_usocket.c
@@ -330,12 +330,9 @@ __usock_write(struct vr_usocket *usockp)
 
 retry_write:
 #ifdef VR_DPDK_TX_PKT_DUMP
-    /* TODO: too much writes */
-    if (len != 8) {
-        RTE_LOG(DEBUG, USOCK, "%s: FD %d writing %d bytes\n",
-                    __func__, usockp->usock_fd, len);
-        rte_hexdump(stdout, "usock buffer", buf, len);
-    }
+    RTE_LOG(DEBUG, USOCK, "%s[%lx]: FD %d writing %d bytes\n",
+                __func__, pthread_self(), usockp->usock_fd, len);
+    rte_hexdump(stdout, "usock buffer", buf, len);
 #endif
     ret = write(usockp->usock_fd, buf, len);
     if (ret > 0) {
@@ -574,13 +571,10 @@ __usock_read(struct vr_usocket *usockp)
 retry_read:
     ret = read(usockp->usock_fd, buf + offset, toread);
 #ifdef VR_DPDK_RX_PKT_DUMP
-    /* TODO: too many reads */
-    if (ret != 8) {
-        RTE_LOG(DEBUG, USOCK, "%s: FD %d read returned %d\n", __func__,
-                usockp->usock_fd, ret);
-        if (ret > 0)
-            rte_hexdump(stdout, "usock buffer", buf + offset, ret);
-    }
+    RTE_LOG(DEBUG, USOCK, "%s[%lx]: FD %d read returned %d: %s (%d)\n", __func__,
+            pthread_self(), usockp->usock_fd, ret, strerror(errno), errno);
+    if (ret > 0)
+        rte_hexdump(stdout, "usock buffer", buf + offset, ret);
 #endif
     if (ret <= 0) {
         if (!ret)

--- a/dpdk/vr_dpdk_usocket.c
+++ b/dpdk/vr_dpdk_usocket.c
@@ -724,6 +724,8 @@ usock_alloc(unsigned short proto, unsigned short type)
     return usockp;
 
 error_exit:
+
+    error = errno;
     if (sock_fd >= 0) {
         close(sock_fd);
         sock_fd = -1;
@@ -731,6 +733,7 @@ error_exit:
 
     usock_close(usockp);
     usockp = NULL;
+    errno = error;
 
     return usockp;
 }
@@ -873,7 +876,7 @@ vr_usocket_connect(struct vr_usocket *usockp)
         return -EINVAL;
 
     sun.sun_family = AF_UNIX;
-    bzero(sun.sun_path, sizeof(sun.sun_path));
+    memset(sun.sun_path, 0, sizeof(sun.sun_path));
     strncpy(sun.sun_path, VR_PACKET_AGENT_UNIX_FILE, sizeof(sun.sun_path) - 1);
 
     return connect(usockp->usock_fd, (struct sockaddr *)&sun, sizeof(sun));
@@ -926,7 +929,7 @@ vr_usocket_bind(struct vr_usocket *usockp)
 
     case UNIX:
         sun.sun_family = AF_UNIX;
-        bzero(sun.sun_path, sizeof(sun.sun_path));
+        memset(sun.sun_path, 0, sizeof(sun.sun_path));
         strncpy(sun.sun_path, VR_NETLINK_UNIX_FILE, sizeof(sun.sun_path) - 1);
         addr = (struct sockaddr *)&sun;
         addrlen = sizeof(sun);
@@ -938,7 +941,7 @@ vr_usocket_bind(struct vr_usocket *usockp)
 
     case RAW:
         sun.sun_family = AF_UNIX;
-        bzero(sun.sun_path, sizeof(sun.sun_path));
+        memset(sun.sun_path, 0, sizeof(sun.sun_path));
         strncpy(sun.sun_path, VR_PACKET_UNIX_FILE, sizeof(sun.sun_path) - 1);
         addr = (struct sockaddr *)&sun;
         addrlen = sizeof(sun);

--- a/dpdk/vr_dpdk_virtio.c
+++ b/dpdk/vr_dpdk_virtio.c
@@ -1,0 +1,776 @@
+/*
+ * vr_dpdk_virtio.c - implements DPDK forwarding infrastructure for
+ * virtio interfaces. The virtio data structures are setup by the user
+ * space vhost server.
+ *
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+
+#include <stdint.h>
+#include <linux/vhost.h>
+#include <linux/virtio_net.h>
+#include <sys/eventfd.h>
+
+#include "vr_dpdk.h"
+#include "vr_dpdk_virtio.h"
+#include "qemu_uvhost.h"
+#include "vr_uvhost_client.h"
+
+#include <rte_malloc.h>
+
+void *vr_dpdk_vif_clients[VR_MAX_INTERFACES];
+vr_dpdk_virtioq_t vr_dpdk_virtio_rxqs[VR_MAX_INTERFACES][RTE_MAX_LCORE];
+vr_dpdk_virtioq_t vr_dpdk_virtio_txqs[VR_MAX_INTERFACES][RTE_MAX_LCORE];
+
+static int dpdk_virtio_from_vm_rx(void *arg, struct rte_mbuf **pkts,
+                                  uint32_t max_pkts);
+static int dpdk_virtio_to_vm_tx(void *arg, struct rte_mbuf *pkt);
+static int dpdk_virtio_to_vm_flush(void *arg);
+
+struct rte_port_in_ops dpdk_virtio_reader_ops = {
+    .f_create = NULL,
+    .f_free = NULL,
+    .f_rx = dpdk_virtio_from_vm_rx,
+};
+
+struct rte_port_out_ops dpdk_virtio_writer_ops = {
+    .f_create = NULL,
+    .f_free = NULL,
+    .f_tx = dpdk_virtio_to_vm_tx,
+    .f_tx_bulk = NULL, /* TODO: not implemented */
+    .f_flush = dpdk_virtio_to_vm_flush,
+};
+
+/*
+ * vr_dpdk_virtio_nrxqs - returns the number of receives queues for a virtio
+ * interface.
+ */
+uint16_t
+vr_dpdk_virtio_nrxqs(struct vr_interface *vif)
+{
+    return 1;
+}
+
+/*
+ * vr_dpdk_virtio_ntxqs - returns the number of transmit queues for a virtio
+ * interface.
+ */
+uint16_t
+vr_dpdk_virtio_ntxqs(struct vr_interface *vif)
+{
+    return 1;
+}
+
+/*
+ * dpdk_virtio_rx_queue_release - releases a virtio RX queue.
+ *
+ * Returns nothing.
+ */
+static void
+dpdk_virtio_rx_queue_release(unsigned lcore_id, struct vr_interface *vif)
+{
+    struct vr_dpdk_lcore *lcore = vr_dpdk.lcores[lcore_id];
+    struct vr_dpdk_queue *rx_queue = &lcore->lcore_rx_queues[vif->vif_idx];
+    struct vr_dpdk_queue_params *rx_queue_params
+                        = &lcore->lcore_rx_queue_params[vif->vif_idx];
+
+    /* remove the ring from the list of rings to push */
+    dpdk_ring_to_push_remove(rx_queue_params->qp_ring.host_lcore_id,
+            rx_queue_params->qp_ring.ring_p);
+
+    rte_free(rx_queue_params->qp_ring.ring_p);
+
+    /* reset the queue */
+    memset(rx_queue->q_queue_h, 0, sizeof(vr_dpdk_virtioq_t));
+    memset(rx_queue, 0, sizeof(*rx_queue));
+    memset(rx_queue_params, 0, sizeof(*rx_queue_params));
+}
+
+/*
+ * vr_dpdk_virtio_rx_queue_init - initializes a virtio RX queue.
+ *
+ * Returns a pointer to the RX queue on success, NULL otherwise.
+ */
+struct vr_dpdk_queue *
+vr_dpdk_virtio_rx_queue_init(unsigned int lcore_id, struct vr_interface *vif,
+                             unsigned int queue_or_lcore_id)
+{
+    uint16_t queue_id = queue_or_lcore_id;
+    struct vr_dpdk_lcore *lcore = vr_dpdk.lcores[lcore_id];
+    unsigned int vif_idx = vif->vif_idx;
+    struct vr_dpdk_queue *rx_queue = &lcore->lcore_rx_queues[vif_idx];
+    char ring_name[64];
+    struct vr_dpdk_queue_params *rx_queue_params =
+        &lcore->lcore_rx_queue_params[vif_idx];
+    int ret;
+
+    RTE_LOG(INFO, VROUTER, "\tcreating lcore %u RX ring for queue %u vif %u\n",
+        lcore_id, queue_id, vif_idx);
+
+    if (queue_id >= vr_dpdk_virtio_nrxqs(vif)) {
+        return NULL;
+    }
+
+    ret = snprintf(ring_name, sizeof(ring_name), "vif_%d_%" PRIu16 "_ring",
+        vif_idx, queue_id);
+    if (ret >= sizeof(ring_name))
+        goto error;
+
+    vr_dpdk_virtio_rxqs[vif_idx][queue_id].vdv_pring =
+        vr_dpdk_ring_allocate(lcore_id, ring_name, VR_DPDK_VIRTIO_TX_RING_SZ);
+    if (vr_dpdk_virtio_rxqs[vif_idx][queue_id].vdv_pring == NULL)
+        goto error;
+
+    vr_dpdk_virtio_rxqs[vif_idx][queue_id].vdv_pring_dst_lcore_id =
+        vr_dpdk_phys_lcore_least_used_get();
+    if (vr_dpdk_virtio_rxqs[vif_idx][queue_id].vdv_pring_dst_lcore_id ==
+        RTE_MAX_LCORE) {
+        vr_dpdk_virtio_rxqs[vif_idx][queue_id].vdv_pring_dst_lcore_id =
+            vr_dpdk_lcore_least_used_get();
+    }
+
+    dpdk_ring_to_push_add(
+        vr_dpdk_virtio_rxqs[vif_idx][queue_id].vdv_pring_dst_lcore_id,
+        vr_dpdk_virtio_rxqs[vif_idx][queue_id].vdv_pring, NULL);
+
+    rx_queue->rxq_ops = dpdk_virtio_reader_ops;
+    vr_dpdk_virtio_rxqs[vif_idx][queue_id].vdv_ready_state = VQ_NOT_READY;
+    vr_dpdk_virtio_rxqs[vif_idx][queue_id].vdv_zero_copy = 0;
+    vr_dpdk_virtio_rxqs[vif_idx][queue_id].vdv_soft_avail_idx = 0;
+    vr_dpdk_virtio_rxqs[vif_idx][queue_id].vdv_soft_used_idx = 0;
+    vr_dpdk_virtio_rxqs[vif_idx][queue_id].vdv_vif_idx = vif->vif_idx;
+    rx_queue->q_queue_h = (void *) &vr_dpdk_virtio_rxqs[vif_idx][queue_id];
+    rx_queue->rxq_burst_size = VR_DPDK_VIRTIO_RX_BURST_SZ;
+    rx_queue->q_vif = vif;
+
+    /* store queue params */
+    rx_queue_params->qp_release_op = &dpdk_virtio_rx_queue_release;
+    rx_queue_params->qp_ring.ring_p =
+                vr_dpdk_virtio_rxqs[vif_idx][queue_id].vdv_pring;
+    rx_queue_params->qp_ring.host_lcore_id =
+        vr_dpdk_virtio_rxqs[vif_idx][queue_id].vdv_pring_dst_lcore_id;
+
+    return rx_queue;
+
+error:
+    RTE_LOG(ERR, VROUTER, "\terror creating lcore %u RX ring for queue %u vif %u\n",
+        lcore_id, queue_id, vif_idx);
+    return NULL;
+}
+
+/*
+ * dpdk_virtio_tx_queue_release - releases a virtio TX queue.
+ *
+ * Returns nothing.
+ */
+static void
+dpdk_virtio_tx_queue_release(unsigned lcore_id, struct vr_interface *vif)
+{
+    struct vr_dpdk_lcore *lcore = vr_dpdk.lcores[lcore_id];
+    struct vr_dpdk_queue *tx_queue = &lcore->lcore_tx_queues[vif->vif_idx];
+    struct vr_dpdk_queue_params *tx_queue_params
+                        = &lcore->lcore_tx_queue_params[vif->vif_idx];
+
+    tx_queue->txq_ops.f_tx = NULL;
+    rte_wmb();
+
+    /* reset the queue */
+    memset(tx_queue->q_queue_h, 0, sizeof(vr_dpdk_virtioq_t));
+    memset(tx_queue, 0, sizeof(*tx_queue));
+    memset(tx_queue_params, 0, sizeof(*tx_queue_params));
+}
+
+/*
+ * vr_dpdk_virtio_tx_queue_init - initializes a virtio TX queue.
+ *
+ * Returns a pointer to the TX queue on success, NULL otherwise.
+ */
+struct vr_dpdk_queue *
+vr_dpdk_virtio_tx_queue_init(unsigned int lcore_id, struct vr_interface *vif,
+                             unsigned int queue_or_lcore_id)
+{
+    uint16_t queue_id = queue_or_lcore_id;
+    struct vr_dpdk_lcore *lcore = vr_dpdk.lcores[lcore_id];
+    unsigned int vif_idx = vif->vif_idx;
+    struct vr_dpdk_queue *tx_queue = &lcore->lcore_tx_queues[vif_idx];
+    struct vr_dpdk_queue_params *tx_queue_params
+                = &lcore->lcore_tx_queue_params[vif_idx];
+
+    if (queue_id >= vr_dpdk_virtio_ntxqs(vif)) {
+        return NULL;
+    }
+
+    tx_queue->txq_ops = dpdk_virtio_writer_ops;
+    vr_dpdk_virtio_txqs[vif_idx][queue_id].vdv_ready_state = VQ_NOT_READY;
+    vr_dpdk_virtio_txqs[vif_idx][queue_id].vdv_zero_copy = 0;
+    vr_dpdk_virtio_txqs[vif_idx][queue_id].vdv_soft_avail_idx = 0;
+    vr_dpdk_virtio_txqs[vif_idx][queue_id].vdv_soft_used_idx = 0;
+    vr_dpdk_virtio_txqs[vif_idx][queue_id].vdv_vif_idx = vif->vif_idx;
+    vr_dpdk_virtio_txqs[vif_idx][queue_id].vdv_tx_mbuf_count = 0;
+    tx_queue->q_queue_h = (void *) &vr_dpdk_virtio_txqs[vif_idx][queue_id];
+    tx_queue->q_vif = vif;
+
+    /* store queue params */
+    tx_queue_params->qp_release_op = &dpdk_virtio_tx_queue_release;
+
+    return tx_queue;
+}
+
+/*
+ * vr_dpdk_guest_phys_to_host_virt - convert a guest physical address
+ * to a host virtual address. Uses the guest memory map stored in the
+ * vhost client for the guest interface.
+ *
+ * Returns address on success, NULL otherwise.
+ */
+static char *
+vr_dpdk_guest_phys_to_host_virt(vr_dpdk_virtioq_t *vq, uint64_t paddr)
+{
+    int i;
+    vr_uvh_client_t *vru_cl;
+    vr_uvh_client_mem_region_t *reg;
+
+    vru_cl = vr_dpdk_virtio_get_vif_client(vq->vdv_vif_idx);
+    if (vru_cl == NULL) {
+        return NULL;
+    }
+
+    for (i = 0; i < vru_cl->vruc_num_mem_regions; i++) {
+        reg = &vru_cl->vruc_mem_regions[i];
+
+        if ((paddr >= reg->vrucmr_phys_addr) &&
+                (paddr <= (reg->vrucmr_phys_addr + reg->vrucmr_size))) {
+            return ((char *) reg->vrucmr_mmap_addr) +
+                        (paddr - reg->vrucmr_phys_addr);
+        }
+    }
+
+    return NULL;
+}
+
+/*
+ * vr_dpdk_virtio_get_mempool - get the mempool to use for receiving
+ * packets from VMs.
+ */
+static struct rte_mempool *
+vr_dpdk_virtio_get_mempool(void)
+{
+    return vr_dpdk.virtio_mempool;
+}
+
+/*
+ * dpdk_virtio_from_vm_rx - receive packets from a virtio client so that
+ * the packets can be handed to vrouter for forwarding. the virtio client is
+ * usually a VM.
+ *
+ * Returns the number of packets to be sent to vrouter (0 if there is nothing
+ * to do).
+ */
+static int
+dpdk_virtio_from_vm_rx(void *arg, struct rte_mbuf **pkts, uint32_t max_pkts)
+{
+    vr_dpdk_virtioq_t *vq = (vr_dpdk_virtioq_t *) arg;
+    uint16_t vq_hard_avail_idx, vq_hard_used_idx, i;
+    uint16_t num_pkts, next_desc_idx, next_avail_idx, pkts_sent = 0;
+    struct vring_desc *desc;
+    char *pkt_addr;
+    struct rte_mbuf *mbuf;
+    uint32_t pkt_len;
+
+    if (vq->vdv_ready_state == VQ_NOT_READY) {
+        return 0;
+    }
+
+    vq_hard_avail_idx = (*((volatile uint16_t *)&vq->vdv_avail->idx));
+
+    /*
+     * Unsigned subtraction gives the right result even with wrap around.
+     */
+    num_pkts = vq_hard_avail_idx - vq->vdv_soft_avail_idx;
+    if (num_pkts == 0) {
+        return 0;
+    }
+
+    if (num_pkts > max_pkts) {
+        num_pkts = max_pkts;
+    }
+
+    RTE_LOG(DEBUG, VROUTER, "%s: num_pkts=%u\n", __func__, num_pkts);
+    for (i = 0; i < num_pkts; i++) {
+        next_avail_idx = (vq->vdv_soft_avail_idx + i) &
+                             (vq->vdv_vvs.num - 1);
+        next_desc_idx = vq->vdv_avail->ring[next_avail_idx];
+        desc = &vq->vdv_desc[next_desc_idx];
+
+        /*
+         * Ignore virtio header in first descriptor as we don't support
+         * mergeable receive buffers yet. Before that, move the descriptors
+         * (chain of 2) to the used list. The used index will, however, only
+         * be updated at the end of the loop.
+         */
+        vq->vdv_used->ring[next_avail_idx].id = next_desc_idx;
+        vq->vdv_used->ring[next_avail_idx].len = 0;
+        if (desc->flags & VRING_DESC_F_NEXT) {
+            /*
+             * TODO - make sure desc->next is sane
+             */
+            desc = &vq->vdv_desc[desc->next];
+            pkt_addr = vr_dpdk_guest_phys_to_host_virt(vq, desc->addr);
+            pkt_len = desc->len;
+        } else {
+            pkt_addr = vr_dpdk_guest_phys_to_host_virt(vq, desc->addr);
+            if (pkt_addr) {
+                pkt_addr += sizeof(struct virtio_net_hdr);
+                pkt_len = desc->len - sizeof(struct virtio_net_hdr);
+            }
+        }
+
+        if (pkt_addr) {
+            mbuf = rte_pktmbuf_alloc(vr_dpdk_virtio_get_mempool());
+            if (mbuf != NULL) {
+                mbuf->pkt.data_len = pkt_len;
+                mbuf->pkt.pkt_len = mbuf->pkt.data_len;
+
+                rte_memcpy(mbuf->pkt.data, pkt_addr, pkt_len);
+                pkts[pkts_sent] = mbuf;
+                pkts_sent++;
+            }
+        }
+    }
+
+    /*
+     * TODO - might need to kick guest.
+     */
+    rte_wmb();
+    vq->vdv_soft_avail_idx += num_pkts;
+    vq_hard_used_idx = (*((volatile uint16_t *)&vq->vdv_used->idx));
+    *((volatile uint16_t *) &vq->vdv_used->idx) = vq_hard_used_idx + num_pkts;
+
+    return pkts_sent;
+}
+
+/*
+ * dpdk_virtio_to_vm_tx - sends a packet from vrouter to a virtio client. The
+ * virtio client is usually a VM.
+ *
+ * Returns nothing.
+ */
+static int
+dpdk_virtio_to_vm_tx(void *arg, struct rte_mbuf *pkt)
+{
+    vr_dpdk_virtioq_t *vq = (vr_dpdk_virtioq_t *) arg;
+
+    if (vq->vdv_ready_state == VQ_NOT_READY) {
+        rte_pktmbuf_free(pkt);
+
+        return 0;
+    }
+
+    vq->vdv_tx_mbuf[vq->vdv_tx_mbuf_count++] = pkt;
+    if (vq->vdv_tx_mbuf_count >= VR_DPDK_VIRTIO_TX_BURST_SZ) {
+        dpdk_virtio_to_vm_flush(vq);
+    }
+
+    return 0;
+}
+
+/*
+ * dpdk_virtio_to_vm_flush - flushes packets from vrouter to a virtio client.
+ * The virtio client is usually a VM.
+ *
+ * Returns nothing.
+ */
+static int
+dpdk_virtio_to_vm_flush(void *arg)
+{
+    vr_dpdk_virtioq_t *vq = (vr_dpdk_virtioq_t *) arg;
+    uint16_t i;
+    uint16_t num_buf_posted, vq_hard_avail_idx, vq_hard_used_idx, num_pkts;
+    uint16_t next_desc_idx, next_avail_idx, size;
+    struct vring_desc *desc;
+    char *buf_addr;
+    struct virtio_net_hdr vhdr = {0, 0, 0, 0, 0, 0};
+
+    if (vq->vdv_ready_state == VQ_NOT_READY) {
+        return 0;
+    }
+
+    if (vq->vdv_tx_mbuf_count == 0) {
+        return 0;
+    }
+
+    vq_hard_avail_idx = (*((volatile uint16_t *)&vq->vdv_avail->idx));
+
+    /*
+     * Unsigned subtraction gives the right result even with wrap around.
+     */
+    num_buf_posted = vq_hard_avail_idx - vq->vdv_soft_avail_idx;
+    if (num_buf_posted < vq->vdv_tx_mbuf_count) {
+        num_pkts = num_buf_posted;
+    } else {
+        num_pkts = vq->vdv_tx_mbuf_count;
+    }
+
+    for (i = 0; i < num_pkts; i++) {
+        next_avail_idx = (vq->vdv_soft_avail_idx + i) &
+                             (vq->vdv_vvs.num - 1);
+        next_desc_idx = vq->vdv_avail->ring[next_avail_idx];
+
+        /*
+         * Move the descriptor (single or chain of 2) to the used list. The
+         * used index will, however, only be updated at the end of the loop.
+         * This needs to be done even if any failures occur below in the loop.
+         * Set the descriptor length to 0 for now and update it at the end
+         * of the loop if there were no errors.
+         */
+        vq->vdv_used->ring[next_avail_idx].id = next_desc_idx;
+        vq->vdv_used->ring[next_avail_idx].len = 0;
+
+        desc = &vq->vdv_desc[next_desc_idx];
+        buf_addr = vr_dpdk_guest_phys_to_host_virt(vq, desc->addr);
+        if (buf_addr == NULL) {
+            rte_pktmbuf_free(vq->vdv_tx_mbuf[i]);
+            continue;
+        }
+
+        /*
+         * No support for checksum offload or GSO at the moment, so zero
+         * out the virtio header.
+         */
+        size = sizeof(vhdr);
+        rte_memcpy(buf_addr, &vhdr, size);
+        buf_addr += sizeof(vhdr);
+
+        /*
+         * If the descriptor has VRING_DESC_F_NEXT set, the virtio_net header
+         * and packet data use separate descriptors.
+         */
+        if (desc->flags & VRING_DESC_F_NEXT) {
+            desc->len = sizeof(struct virtio_net_hdr);
+            /*
+             * TODO: verify that desc->next is sane below.
+             */
+            desc = &vq->vdv_desc[desc->next];
+
+            buf_addr = vr_dpdk_guest_phys_to_host_virt(vq, desc->addr);
+            if (buf_addr == NULL) {
+                rte_pktmbuf_free(vq->vdv_tx_mbuf[i]);
+                continue;
+            }
+
+            desc->len = rte_pktmbuf_data_len(vq->vdv_tx_mbuf[i]);
+        } else {
+            desc->len = sizeof(struct virtio_net_hdr) +
+                            rte_pktmbuf_data_len(vq->vdv_tx_mbuf[i]);
+        }
+
+        rte_memcpy(buf_addr, vq->vdv_tx_mbuf[i]->pkt.data,
+                   rte_pktmbuf_data_len(vq->vdv_tx_mbuf[i]));
+
+        vq->vdv_used->ring[next_avail_idx].len =
+            sizeof(struct virtio_net_hdr) +
+            rte_pktmbuf_data_len(vq->vdv_tx_mbuf[i]);
+
+        rte_pktmbuf_free(vq->vdv_tx_mbuf[i]);
+    }
+
+    /*
+     * Free any packets that could not be sent to the VM because it didn't
+     * post receive buffers soon enough.
+     */
+    for (; i < vq->vdv_tx_mbuf_count; i++) {
+        /*
+         * TODO: increment stats here
+         */
+        rte_pktmbuf_free(vq->vdv_tx_mbuf[i]);
+    }
+
+    vq->vdv_tx_mbuf_count = 0;
+
+    /*
+     * Now update the used index in the vring.
+     * TODO - need memory barrier + VM kick here.
+     */
+    vq->vdv_soft_avail_idx += num_pkts;
+    vq_hard_used_idx = (*((volatile uint16_t *)&vq->vdv_used->idx));
+    *((volatile uint16_t *) &vq->vdv_used->idx) = vq_hard_used_idx + num_pkts;
+
+    /*
+     * If the VM did not want to be interrupted (i.e if it uses DPDK), do
+     * not raise an interrupt. Otherwise, use eventfd to raise an interrupt
+     * in the guest.
+     */
+    if (vq->vdv_avail->flags & VRING_AVAIL_F_NO_INTERRUPT) {
+        return 0;
+    }
+
+    eventfd_write(vq->vdv_callfd, 1);
+
+    return 0;
+}
+
+/*
+ * vr_dpdk_virtio_set_vring_base - sets the vring base using data sent by
+ * vhost client.
+ *
+ * Returns 0 on success, -1 otherwise.
+ */
+int
+vr_dpdk_virtio_set_vring_base(unsigned int vif_idx, unsigned int vring_idx,
+                               unsigned int vring_base)
+{
+    vr_dpdk_virtioq_t *vq;
+
+    if ((vif_idx >= VR_MAX_INTERFACES) || (vring_idx >= (2 * RTE_MAX_LCORE))) {
+        return -1;
+    }
+
+    /*
+     * RX rings are even numbered and TX rings are odd numbered from the
+     * VM's point of view. From vrouter's point of view, VM's TX ring is
+     * vrouter's RX ring and vice versa.
+     */
+    if (vring_idx & 1) {
+        vq = &vr_dpdk_virtio_rxqs[vif_idx][vring_idx/2];
+    } else {
+        vq = &vr_dpdk_virtio_txqs[vif_idx][vring_idx/2];
+    }
+
+    vq->vdv_base_idx = vring_base;
+    return 0;
+}
+
+/*
+ * vr_dpdk_virtio_get_vring_base - gets the vring base for the specified vring
+ * sent by the vhost client.
+ *
+ * Returns 0 on success, -1 otherwise.
+ */
+int
+vr_dpdk_virtio_get_vring_base(unsigned int vif_idx, unsigned int vring_idx,
+                               unsigned int *vring_basep)
+{
+    vr_dpdk_virtioq_t *vq;
+
+    if ((vif_idx >= VR_MAX_INTERFACES) || (vring_idx >= (2 * RTE_MAX_LCORE))) {
+        return -1;
+    }
+
+    /*
+     * RX rings are even numbered and TX rings are odd numbered from the
+     * VM's point of view. From vrouter's point of view, VM's TX ring is
+     * vrouter's RX ring and vice versa.
+     */
+    if (vring_idx & 1) {
+        vq = &vr_dpdk_virtio_rxqs[vif_idx][vring_idx/2];
+    } else {
+        vq = &vr_dpdk_virtio_txqs[vif_idx][vring_idx/2];
+    }
+
+    *vring_basep = vq->vdv_base_idx;
+
+    /*
+     * This is usually called when qemu shuts down a virtio queue. Set the
+     * state to indicate that this queue should not be used any more.
+     *
+     * TODO: need memory barrier and rcu_synchronize here.
+     */
+    vq->vdv_ready_state = VQ_NOT_READY;
+    vq->vdv_soft_avail_idx = 0;
+    vq->vdv_soft_used_idx = 0;
+
+    return 0;
+}
+
+/*
+ * vr_dpdk_set_vring_addr - Sets the address of the virtio descruptor and
+ * available/used rings based on messages sent by the vhost client.
+ *
+ * Returns 0 on suucess, -1 otherwise.
+ */
+int
+vr_dpdk_set_vring_addr(unsigned int vif_idx, unsigned int vring_idx,
+                       struct vring_desc *vrucv_desc,
+                       struct vring_avail *vrucv_avail,
+                       struct vring_used *vrucv_used)
+{
+    vr_dpdk_virtioq_t *vq;
+
+    if ((vif_idx >= VR_MAX_INTERFACES) || (vring_idx >= (2 * RTE_MAX_LCORE))) {
+        return -1;
+    }
+
+    /*
+     * RX rings are even numbered and TX rings are odd numbered from the
+     * VM's point of view. From vrouter's point of view, VM's TX ring is
+     * vrouter's RX ring and vice versa.
+     */
+    if (vring_idx & 1) {
+        vq = &vr_dpdk_virtio_rxqs[vif_idx][vring_idx/2];
+    } else {
+        vq = &vr_dpdk_virtio_txqs[vif_idx][vring_idx/2];
+    }
+
+    vq->vdv_desc = vrucv_desc;
+    vq->vdv_avail = vrucv_avail;
+    vq->vdv_used = vrucv_used;
+
+    /*
+     * Tell the guest that it need not interrupt vrouter when it updates the
+     * available ring (as vrouter is polling it).
+     */
+    vq->vdv_used->flags |= VRING_USED_F_NO_NOTIFY;
+
+    return 0;
+}
+
+/*
+ * vr_dpdk_set_ring_num_desc - sets the number of descriptors in a vring
+ * based on messages from the vhost client.
+ *
+ * Returns 0 on success, -1 otherwise.
+ */
+int
+vr_dpdk_set_ring_num_desc(unsigned int vif_idx, unsigned int vring_idx,
+                          unsigned int num_desc)
+{
+    vr_dpdk_virtioq_t *vq;
+
+    if ((vif_idx >= VR_MAX_INTERFACES) || (vring_idx >= (2 * RTE_MAX_LCORE))) {
+        return -1;
+    }
+
+    /*
+     * RX rings are even numbered and TX rings are odd numbered from the
+     * VM's point of view. From vrouter's point of view, VM's TX ring is
+     * vrouter's RX ring and vice versa.
+     */
+    if (vring_idx & 1) {
+        vq = &vr_dpdk_virtio_rxqs[vif_idx][vring_idx/2];
+    } else {
+        vq = &vr_dpdk_virtio_txqs[vif_idx][vring_idx/2];
+    }
+
+    vq->vdv_vvs.index = vring_idx;
+    vq->vdv_vvs.num = num_desc;
+
+    return 0;
+}
+
+/*
+ * vr_dpdk_set_ring_callfd - set the eventd used to raise interrupts in
+ * the guest (if required). Returns 0 on success, -1 otherwise.
+ */
+int
+vr_dpdk_set_ring_callfd(unsigned int vif_idx, unsigned int vring_idx,
+                        int callfd)
+{
+    vr_dpdk_virtioq_t *vq;
+
+    if ((vif_idx >= VR_MAX_INTERFACES) || (vring_idx >= (2 * RTE_MAX_LCORE))) {
+        return -1;
+    }
+
+    /*
+     * RX rings are even numbered and TX rings are odd numbered from the
+     * VM's point of view. From vrouter's point of view, VM's TX ring is
+     * vrouter's RX ring and vice versa.
+     */
+    if (vring_idx & 1) {
+        vq = &vr_dpdk_virtio_rxqs[vif_idx][vring_idx/2];
+    } else {
+        vq = &vr_dpdk_virtio_txqs[vif_idx][vring_idx/2];
+    }
+
+    vq->vdv_callfd = callfd;
+
+    return 0;
+}
+
+/*
+ * vr_dpdk_set_virtq_ready - sets the virtio queue ready state to indicate
+ * whether forwarding can start on the virtio queue or not.
+ *
+ * Returns 0 on success, -1 otherwise.
+ */
+int
+vr_dpdk_set_virtq_ready(unsigned int vif_idx, unsigned int vring_idx,
+                        vq_ready_state_t ready)
+{
+    vr_dpdk_virtioq_t *vq;
+
+    if ((vif_idx >= VR_MAX_INTERFACES) || (vring_idx >= (2 * RTE_MAX_LCORE))) {
+        return -1;
+    }
+
+    /*
+     * RX rings are even numbered and TX rings are odd numbered from the
+     * VM's point of view. From vrouter's point of view, VM's TX ring is
+     * vrouter's RX ring and vice versa.
+     */
+    if (vring_idx & 1) {
+        vq = &vr_dpdk_virtio_rxqs[vif_idx][vring_idx/2];
+    } else {
+        vq = &vr_dpdk_virtio_txqs[vif_idx][vring_idx/2];
+    }
+
+    vq->vdv_ready_state = ready;
+
+    return 0;
+}
+
+/*
+ * vr_dpdk_virtio_set_vif_client - sets a pointer to per vif state. Currently
+ * used to store a pointer to the vhost client structure.
+ *
+ * Returns nothing.
+ */
+void
+vr_dpdk_virtio_set_vif_client(unsigned int idx, void *client)
+{
+    if (idx >= VR_MAX_INTERFACES) {
+        return;
+    }
+
+    vr_dpdk_vif_clients[idx] = client;
+
+    return;
+}
+
+/*
+ * vr_dpdk_virtio_get_vif_client - returns a pointer to per vif state if it
+ * exists, NULL otherwise.
+ */
+void *
+vr_dpdk_virtio_get_vif_client(unsigned int idx)
+{
+    if (idx >= VR_MAX_INTERFACES) {
+        return NULL;
+    }
+
+    return vr_dpdk_vif_clients[idx];
+}
+
+/*
+ * vr_dpdk_virtio_enq_pkts_to_phys_lcore - enqueue packets received on a
+ * virtio interface queue onto a ring that will be handled by the lcore
+ * assigned to that queue. This lcore will then transmit the packet out the
+ * wire if required.
+ *
+ * Returns nothing.
+ */
+void
+vr_dpdk_virtio_enq_pkts_to_phys_lcore(struct vr_dpdk_queue *rx_queue,
+                                      struct vr_packet **pkt_arr,
+                                      uint32_t npkts)
+{
+    vr_dpdk_virtioq_t *vq;
+    struct rte_ring *vq_pring;
+
+    vq = (vr_dpdk_virtioq_t *) rx_queue->q_queue_h;
+    vq_pring = vq->vdv_pring;
+
+    rte_ring_sp_enqueue_bulk(vq_pring, (void **) pkt_arr, npkts);
+
+    return;
+}

--- a/dpdk/vr_dpdk_virtio.c
+++ b/dpdk/vr_dpdk_virtio.c
@@ -124,10 +124,8 @@ vr_dpdk_virtio_rx_queue_init(unsigned int lcore_id, struct vr_interface *vif,
     vr_dpdk_virtio_rxqs[vif_idx][queue_id].vdv_pring_dst_lcore_id =
         vr_dpdk_phys_lcore_least_used_get();
     if (vr_dpdk_virtio_rxqs[vif_idx][queue_id].vdv_pring_dst_lcore_id ==
-        RTE_MAX_LCORE) {
-        vr_dpdk_virtio_rxqs[vif_idx][queue_id].vdv_pring_dst_lcore_id =
-            vr_dpdk_lcore_least_used_get();
-    }
+        RTE_MAX_LCORE)
+        goto error;
 
     dpdk_ring_to_push_add(
         vr_dpdk_virtio_rxqs[vif_idx][queue_id].vdv_pring_dst_lcore_id,
@@ -153,6 +151,10 @@ vr_dpdk_virtio_rx_queue_init(unsigned int lcore_id, struct vr_interface *vif,
     return rx_queue;
 
 error:
+    if (vr_dpdk_virtio_rxqs[vif_idx][queue_id].vdv_pring) {
+        rte_free(vr_dpdk_virtio_rxqs[vif_idx][queue_id].vdv_pring);
+        vr_dpdk_virtio_rxqs[vif_idx][queue_id].vdv_pring = NULL;
+    }
     RTE_LOG(ERR, VROUTER, "\terror creating lcore %u RX ring for queue %u vif %u\n",
         lcore_id, queue_id, vif_idx);
     return NULL;

--- a/dpdk/vr_dpdk_virtio.h
+++ b/dpdk/vr_dpdk_virtio.h
@@ -1,0 +1,76 @@
+/*
+ * vr_dpdk_virtio.h - header for DPDK virtio forwarding infrastructure.
+ *
+ *
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+
+#ifndef __VR_DPDK_VIRTIO_H__
+#define __VR_DPDK_VIRTIO_H__
+
+/*
+ * Burst size for packets from a VM
+ */
+#define VR_DPDK_VIRTIO_RX_BURST_SZ VR_DPDK_MAX_BURST_SZ
+/*
+ * Burst size for packets to a VM
+ */
+#define VR_DPDK_VIRTIO_TX_BURST_SZ VR_DPDK_MAX_BURST_SZ
+
+/*
+ * Size of ring to send packets from virtio RX queue to lcore for forwarding
+ */
+#define VR_DPDK_VIRTIO_TX_RING_SZ (64 * VR_DPDK_TX_RING_SZ)
+
+typedef enum vq_ready_state {
+    VQ_NOT_READY = 1,
+    VQ_READY,
+} vq_ready_state_t;
+
+typedef struct vr_dpdk_virtioq {
+    volatile vq_ready_state_t vdv_ready_state;
+    int vdv_enabled_state;
+    unsigned int vdv_vif_idx;
+    int vdv_zero_copy;
+    struct vring_desc *vdv_desc;
+    struct vring_avail *vdv_avail;
+    struct vring_used *vdv_used;
+    unsigned int vdv_base_idx;
+    struct vhost_vring_state vdv_vvs;
+    uint16_t vdv_soft_avail_idx;
+    uint16_t vdv_soft_used_idx;
+    struct rte_mbuf *vdv_tx_mbuf[2 * VR_DPDK_VIRTIO_TX_BURST_SZ];
+    uint32_t vdv_tx_mbuf_count;
+    struct rte_ring *vdv_pring;
+    unsigned vdv_pring_dst_lcore_id;
+    int vdv_callfd;
+} vr_dpdk_virtioq_t;
+
+uint16_t vr_dpdk_virtio_nrxqs(struct vr_interface *vif);
+uint16_t vr_dpdk_virtio_ntxqs(struct vr_interface *vif);
+struct vr_dpdk_queue *
+vr_dpdk_virtio_rx_queue_init(unsigned int lcore_id, struct vr_interface *vif,
+                             unsigned int queue_id);
+struct vr_dpdk_queue *
+vr_dpdk_virtio_tx_queue_init(unsigned int lcore_id, struct vr_interface *vif,
+                             unsigned int queue_id);
+int vr_dpdk_virtio_set_vring_base(unsigned int vif_idx, unsigned int vring_idx,
+                                   unsigned int vring_base);
+int vr_dpdk_virtio_get_vring_base(unsigned int vif_idx, unsigned int vring_idx,
+                                  unsigned int *vring_basep);
+int vr_dpdk_set_vring_addr(unsigned int vif_idx, unsigned int vring_idx,
+                           struct vring_desc *vrucv_desc,
+                           struct vring_avail *vrucv_avail,
+                           struct vring_used *vrucv_used);
+int vr_dpdk_set_ring_num_desc(unsigned int vif_idx, unsigned int vring_idx,
+                              unsigned int num_desc);
+int vr_dpdk_set_ring_callfd(unsigned int vif_idx, unsigned int vring_idx,
+                            int callfd);
+int vr_dpdk_set_virtq_ready(unsigned int vif_idx, unsigned int vring_idx,
+                            vq_ready_state_t ready);
+void vr_dpdk_virtio_set_vif_client(unsigned int idx, void *client);
+void *vr_dpdk_virtio_get_vif_client(unsigned int idx);
+void vr_dpdk_virtio_enq_pkts_to_phys_lcore(struct vr_dpdk_queue *rx_queue,
+                                           struct vr_packet **pkt_arr,
+                                           uint32_t npkts);
+#endif /* __VR_DPDK_VIRTIO_H__ */

--- a/dpdk/vr_dpdk_virtio.h
+++ b/dpdk/vr_dpdk_virtio.h
@@ -44,6 +44,7 @@ typedef struct vr_dpdk_virtioq {
     struct rte_ring *vdv_pring;
     unsigned vdv_pring_dst_lcore_id;
     int vdv_callfd;
+    DPDK_DEBUG_VAR(uint32_t vdv_hash);
 } vr_dpdk_virtioq_t;
 
 uint16_t vr_dpdk_virtio_nrxqs(struct vr_interface *vif);

--- a/dpdk/vr_uvhost.c
+++ b/dpdk/vr_uvhost.c
@@ -1,0 +1,141 @@
+/*
+ * vr_uvhost.c - implements a user-space vhost server that peers with
+ * the vhost client inside qemu (version 2.1 and later).
+ *
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <linux/vhost.h>
+#include <errno.h>
+
+#include "vr_dpdk.h"
+#include "vr_uvhost.h"
+#include "vr_uvhost_util.h"
+#include "vr_uvhost_msg.h"
+#include "qemu_uvhost.h"
+#include "vr_uvhost_client.h"
+
+/*
+ * Prototypes
+ */
+static void *vr_uvhost_start(void *arg);
+
+/* Global variables */
+static vr_uvh_exit_callback_t vr_uvhost_exit_fn;
+
+/*
+ * vr_uvhost_init - initializes the user space vhost server and waits
+ * for messages from the netlink thread or qemu clients. The netlink thread
+ * sends messages on a UNIX pipe in order to specify the names of the UNIX
+ * domain socket on which a qemu client will connect. Once this message is
+ * received, the vhost server creates the UNIX domain socket and includes it
+ * in the list of fds it waits on.
+ *
+ * Returns 0 on success, error otherwise.
+ */
+int
+vr_uvhost_init(pthread_t *th, vr_uvh_exit_callback_t exit_fn)
+{
+    if (pthread_create(th, NULL, vr_uvhost_start, NULL)) {
+        return -1;
+    }
+
+    vr_uvhost_exit_fn = exit_fn;
+    return 0;
+}
+
+/*
+ * vr_uvhost_exit - exits the user space vhost server thread. Also forces
+ * other threads in the process to exit by calling the process exit
+ * callback.
+ *
+ * Returns nothing.
+ */
+static void
+vr_uvhost_exit(void)
+{
+    vr_uvhost_exit_fn();
+
+    return;
+}
+
+/*
+ * vr_uvhost_start - starts the user space vhost server
+ *
+ * Returns NULL if an error occurs. Otherwise, it runs forever.
+ */
+static void *
+vr_uvhost_start(void *arg)
+{
+    int s = 0, ret;
+    struct sockaddr_un sun;
+    fd_set *rfdset, *wfdset;
+
+    vr_uvhost_client_init();
+
+    vr_uvhost_log("Starting user space vhost server...\n");
+    s = socket(AF_UNIX, SOCK_SEQPACKET, 0);
+    if (s == -1) {
+        vr_uvhost_log("\terror creating server socket: %s (%d)\n",
+                        strerror(errno), errno);
+        goto error;
+    }
+    vr_uvhost_log("\tserver socket FD is %d\n", s);
+
+    unlink(VR_UVH_NL_SOCK);
+    memset(&sun, 0, sizeof(sun));
+    sun.sun_family = AF_UNIX;
+    strncpy(sun.sun_path, VR_UVH_NL_SOCK, sizeof(sun.sun_path) - 1);
+
+    ret = bind(s, (struct sockaddr *) &sun, sizeof(sun));
+    if (ret == -1) {
+        vr_uvhost_log("\terror binding server FD %d to %s: %s (%d)\n",
+                        s, sun.sun_path, strerror(errno), errno);
+        goto error;
+    }
+
+    if (listen(s, 1) == -1) {
+        vr_uvhost_log("\terror listening server socket FD %d: %s (%d)\n",
+                        s, strerror(errno), errno);
+        goto error;
+    }
+
+    vr_uvhost_fdset_init();
+
+    if (vr_uvhost_add_fd(s, UVH_FD_READ, NULL, vr_uvh_nl_listen_handler)) {
+        vr_uvhost_log("\terror adding server socket FD %d\n", s);
+        goto error;
+    }
+
+    while (1) {
+        vr_uvh_recalc_max_fd();
+        rfdset = vr_uvh_rfdset_p();
+        wfdset = vr_uvh_wfdset_p();
+
+        if (select(vr_uvh_max_fd()+1, rfdset, wfdset, NULL, NULL) == -1) {
+            vr_uvhost_log("\terror selecting FDs: %s (%d)\n",
+                            strerror(errno), errno);
+            goto error;
+        }
+
+        if (vr_uvh_call_fd_handlers()) {
+            vr_uvhost_log("\terror calling socket handlers\n");
+            goto error;
+        }
+    }
+
+error:
+    if (s) {
+        close(s);
+    }
+
+    vr_uvhost_exit();
+
+    return NULL;
+}
+

--- a/dpdk/vr_uvhost.c
+++ b/dpdk/vr_uvhost.c
@@ -80,7 +80,7 @@ vr_uvhost_start(void *arg)
 
     vr_uvhost_client_init();
 
-    vr_uvhost_log("Starting user space vhost server...\n");
+    vr_uvhost_log("Starting uvhost server...\n");
     s = socket(AF_UNIX, SOCK_SEQPACKET, 0);
     if (s == -1) {
         vr_uvhost_log("\terror creating server socket: %s (%d)\n",

--- a/dpdk/vr_uvhost.c
+++ b/dpdk/vr_uvhost.c
@@ -4,6 +4,7 @@
  *
  * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
  */
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/un.h>
@@ -19,6 +20,7 @@
 #include "vr_uvhost_msg.h"
 #include "qemu_uvhost.h"
 #include "vr_uvhost_client.h"
+#include "vr_dpdk_usocket.h"
 
 /*
  * Prototypes
@@ -87,11 +89,12 @@ vr_uvhost_start(void *arg)
     }
     vr_uvhost_log("\tserver socket FD is %d\n", s);
 
-    unlink(VR_UVH_NL_SOCK);
     memset(&sun, 0, sizeof(sun));
     sun.sun_family = AF_UNIX;
     strncpy(sun.sun_path, VR_UVH_NL_SOCK, sizeof(sun.sun_path) - 1);
 
+    mkdir(VR_SOCKET_DIR, VR_SOCKET_DIR_MODE);
+    unlink(sun.sun_path);
     ret = bind(s, (struct sockaddr *) &sun, sizeof(sun));
     if (ret == -1) {
         vr_uvhost_log("\terror binding server FD %d to %s: %s (%d)\n",

--- a/dpdk/vr_uvhost.c
+++ b/dpdk/vr_uvhost.c
@@ -74,7 +74,7 @@ vr_uvhost_exit(void)
 static void *
 vr_uvhost_start(void *arg)
 {
-    int s = 0, ret;
+    int s = 0, ret, err;
     struct sockaddr_un sun;
     fd_set *rfdset, *wfdset;
 
@@ -133,11 +133,15 @@ vr_uvhost_start(void *arg)
     }
 
 error:
+
+    err = errno;
     if (s) {
         close(s);
+        unlink(sun.sun_path);
     }
 
     vr_uvhost_exit();
+    errno = err;
 
     return NULL;
 }

--- a/dpdk/vr_uvhost.h
+++ b/dpdk/vr_uvhost.h
@@ -9,8 +9,8 @@
 
 typedef void (*vr_uvh_exit_callback_t)(void);
 
-#define VR_UVH_NL_SOCK "/tmp/vr_uvh_nl"
-#define VR_NL_UVH_SOCK "/tmp/vr_nl_uvh"
+#define VR_UVH_NL_SOCK VR_SOCKET_DIR"/vr_uvh_nl"
+#define VR_NL_UVH_SOCK VR_SOCKET_DIR"/vr_nl_uvh"
 
 int vr_uvhost_init(pthread_t *th, vr_uvh_exit_callback_t exit_fn);
 

--- a/dpdk/vr_uvhost.h
+++ b/dpdk/vr_uvhost.h
@@ -1,0 +1,18 @@
+/*
+ * vr_uvhost.h - header for user-space vhost server that peers with
+ * the vhost client inside qemu (version 2.1 and later).
+ *
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+#ifndef __VR_UVHOST_H__
+#define __VR_UVHOST_H__
+
+typedef void (*vr_uvh_exit_callback_t)(void);
+
+#define VR_UVH_NL_SOCK "/tmp/vr_uvh_nl"
+#define VR_NL_UVH_SOCK "/tmp/vr_nl_uvh"
+
+int vr_uvhost_init(pthread_t *th, vr_uvh_exit_callback_t exit_fn);
+
+#endif /* __VR_UVHOST_H__ */
+

--- a/dpdk/vr_uvhost_client.c
+++ b/dpdk/vr_uvhost_client.c
@@ -66,6 +66,7 @@ void
 vr_uvhost_del_client(vr_uvh_client_t *vru_cl)
 {
     vru_cl->vruc_fd = -1;
+    unlink(vru_cl->vruc_path);
 
     return;
 }

--- a/dpdk/vr_uvhost_client.c
+++ b/dpdk/vr_uvhost_client.c
@@ -1,0 +1,96 @@
+/*
+ * vr_uvhost_client.c - client handling in user space vhost server that
+ * peers with the vhost client inside qemu (version 2.1 and later).
+ *
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+
+#include <sys/socket.h>
+#include <linux/vhost.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "vr_dpdk.h"
+#include "qemu_uvhost.h"
+#include "vr_uvhost_client.h"
+
+#include <stddef.h>
+
+static vr_uvh_client_t vr_uvh_clients[VR_UVH_MAX_CLIENTS];
+
+/*
+ * vr_uvhost_client_init - initialize the client array.
+ */
+void
+vr_uvhost_client_init(void)
+{
+    int i;
+
+    for (i = 0; i < VR_UVH_MAX_CLIENTS; i++) {
+        vr_uvh_clients[i].vruc_fd = -1;
+    }
+
+    return;
+}
+
+/*
+ * vr_uvhost_new_client - initializes state for a new user space vhost client
+ * FD is a file descriptor for the client socket. path is the UNIX domain
+ * socket path. cidx is the index of the client.
+ *
+ * Returns a pointer to the client state on success, NULL otherwise.
+ */
+vr_uvh_client_t *
+vr_uvhost_new_client(int fd, char *path, int cidx)
+{
+    if (cidx >= VR_UVH_MAX_CLIENTS) {
+        return NULL;
+    }
+
+    if (vr_uvh_clients[cidx].vruc_fd != -1) {
+        return NULL;
+    }
+
+    vr_uvh_clients[cidx].vruc_fd = fd;
+    strncpy(vr_uvh_clients[cidx].vruc_path, path, VR_UNIX_PATH_MAX - 1);
+
+    return &vr_uvh_clients[cidx];
+}
+
+/*
+ * vr_uvhost_del_client - removes a vhost client.
+ *
+ * Returns nothing.
+ */
+void
+vr_uvhost_del_client(vr_uvh_client_t *vru_cl)
+{
+    vru_cl->vruc_fd = -1;
+
+    return;
+}
+
+/*
+ * vr_uvhost_cl_set_fd - set the FD for a user space vhost client
+ */
+void
+vr_uvhost_cl_set_fd(vr_uvh_client_t *vru_cl, int fd)
+{
+    vru_cl->vruc_fd = fd;
+
+    return;
+}
+
+/*
+ * vr_uvhost_get_client - Returns the client at the specified index, NULL if
+ * it cannot be found.
+ */
+vr_uvh_client_t *
+vr_uvhost_get_client(unsigned int cidx)
+{
+    if (cidx >= VR_UVH_MAX_CLIENTS) {
+        return NULL;
+    }
+
+    return &vr_uvh_clients[cidx];
+}

--- a/dpdk/vr_uvhost_client.h
+++ b/dpdk/vr_uvhost_client.h
@@ -1,0 +1,46 @@
+/*
+ * vr_uvhost_client.h - header file for client state handling in user
+ * space vhost server that peers with the vhost client inside qemu (version
+ * 2.1 and later).
+ *
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+
+#ifndef __VR_UVHOST_CLIENT_H__
+#define __VR_UVHOST_CLIENT_H__
+
+/*
+ * VR_UVH_MAX_CLIENTS needs to be the same as VR_MAX_INTERFACES.
+ */
+#define VR_UVH_MAX_CLIENTS (256 + 4096)
+
+typedef struct vr_uvh_client_mem_region {
+    uint64_t vrucmr_phys_addr;
+    uint64_t vrucmr_size;
+    uint64_t vrucmr_user_space_addr;
+    uint64_t vrucmr_mmap_addr;
+} vr_uvh_client_mem_region_t;
+
+typedef struct vr_uvh_client {
+    int vruc_fd;
+    char vruc_path[VR_UNIX_PATH_MAX];
+    char vruc_cmsg[CMSG_SPACE(VHOST_MEMORY_MAX_NREGIONS * sizeof(int))];
+    int vruc_msg_bytes_read;
+    int vruc_fds_sent[VHOST_MEMORY_MAX_NREGIONS];
+    int vruc_num_fds_sent;
+    int vruc_num_mem_regions;
+    vr_uvh_client_mem_region_t vruc_mem_regions[VHOST_MEMORY_MAX_NREGIONS];
+    VhostUserMsg vruc_msg;
+
+    unsigned int vruc_idx;
+    unsigned int vruc_nrxqs;
+    unsigned int vruc_ntxqs;
+} vr_uvh_client_t;
+
+void vr_uvhost_client_init(void);
+vr_uvh_client_t *vr_uvhost_new_client(int fd, char *path, int cidx);
+void vr_uvhost_del_client(vr_uvh_client_t *vru_cl);
+void vr_uvhost_cl_set_fd(vr_uvh_client_t *vru_cl, int fd);
+vr_uvh_client_t *vr_uvhost_get_client(unsigned int cidx);
+#endif /* __VR_UVHOST_CLIENT_H__ */
+

--- a/dpdk/vr_uvhost_msg.c
+++ b/dpdk/vr_uvhost_msg.c
@@ -1,0 +1,824 @@
+/*
+ * vr_uvhost_msg.c - handlers for messages received by the user space
+ * vhost thread.
+ *
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+#include <sys/select.h>
+#include <sys/un.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/socket.h>
+#include <linux/vhost.h>
+#include <stdint.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+
+
+#include "vr_dpdk.h"
+#include "vr_uvhost_util.h"
+#include "vr_uvhost_msg.h"
+#include "qemu_uvhost.h"
+#include "vr_uvhost_client.h"
+#include "vr_dpdk_virtio.h"
+
+typedef int (*vr_uvh_msg_handler_fn)(vr_uvh_client_t *vru_cl);
+
+/*
+ * Prototypes for user space vhost message handlers
+ */
+static int vr_uvmh_get_features(vr_uvh_client_t *vru_cl);
+static int vr_uvhm_set_mem_table(vr_uvh_client_t *vru_cl);
+static int vr_uvhm_set_ring_num_desc(vr_uvh_client_t *vru_cl);
+static int vr_uvhm_set_vring_addr(vr_uvh_client_t *vru_cl);
+static int vr_uvhm_set_vring_base(vr_uvh_client_t *vru_cl);
+static int vr_uvhm_get_vring_base(vr_uvh_client_t *vru_cl);
+static int vr_uvhm_set_call_fd(vr_uvh_client_t *vru_cl);
+
+static vr_uvh_msg_handler_fn vr_uvhost_cl_msg_handlers[] = {
+    NULL,
+    vr_uvmh_get_features,
+    NULL,
+    NULL,
+    NULL,
+    vr_uvhm_set_mem_table,
+    NULL,
+    NULL,
+    vr_uvhm_set_ring_num_desc,
+    vr_uvhm_set_vring_addr,
+    vr_uvhm_set_vring_base,
+    vr_uvhm_get_vring_base,
+    NULL,
+    vr_uvhm_set_call_fd,
+    NULL
+};
+
+/*
+ * vr_uvmh_get_features - handle VHOST_USER_GET_FEATURES message from user space
+ * vhost client.
+ *
+ * Returns 0 on success, -1 otherwise.
+ */
+static int
+vr_uvmh_get_features(vr_uvh_client_t *vru_cl)
+{
+    vru_cl->vruc_msg.u64 = 0;
+    vru_cl->vruc_msg.size = sizeof(vru_cl->vruc_msg.u64);
+
+    return 0;
+}
+
+/*
+ * vr_uvhm_set_mem_table - handles VHOST_USER_SET_MEM_TABLE message from
+ * user space vhost client to learn the memory map of the guest.
+ *
+ * Returns 0 on success, -1 otherwise.
+ */
+static int
+vr_uvhm_set_mem_table(vr_uvh_client_t *vru_cl)
+{
+    int i;
+    vr_uvh_client_mem_region_t *region;
+    VhostUserMemory *vum_msg;
+    uint64_t size;
+
+    vum_msg = &vru_cl->vruc_msg.memory;
+
+    vr_uvhost_log("Num Regions %d\n", vum_msg->nregions);
+    for (i = 0; i < vum_msg->nregions; i++) {
+        vr_uvhost_log("Region %d: physical address 0x%" PRIx64 ", size %"
+                PRIu64 ", offset %" PRIu64 "\n",
+                i, vum_msg->regions[i].guest_phys_addr,
+                vum_msg->regions[i].memory_size,
+                vum_msg->regions[i].mmap_offset);
+
+        if (vru_cl->vruc_fds_sent[i]) {
+            region = &vru_cl->vruc_mem_regions[i];
+
+            region->vrucmr_phys_addr = vum_msg->regions[i].guest_phys_addr;
+            region->vrucmr_size = vum_msg->regions[i].memory_size;
+            region->vrucmr_user_space_addr = vum_msg->regions[i].userspace_addr;
+
+            size = vum_msg->regions[i].mmap_offset +
+                       vum_msg->regions[i].memory_size;
+            region->vrucmr_mmap_addr = (uint64_t)
+                                            mmap(0, size,
+                                            PROT_READ | PROT_WRITE,
+                                            MAP_SHARED,
+                                            vru_cl->vruc_fds_sent[i], 0);
+
+            if (region->vrucmr_mmap_addr == ((uint64_t)MAP_FAILED)) {
+                vr_uvhost_log("mmap for size %d failed for FD %d"
+                        " on vhost client %s (%s)\n",
+                        size,
+                        vru_cl->vruc_fds_sent[i],
+                        vru_cl->vruc_path, strerror(errno));
+                return -1;
+            }
+
+            region->vrucmr_mmap_addr += vum_msg->regions[i].mmap_offset;
+        }
+    }
+
+    vru_cl->vruc_num_mem_regions = vum_msg->nregions;
+
+    return 0;
+}
+
+/*
+ * vr_uvhm_set_ring_num_desc - handles VHOST_USER_SET_VRING_NUM message from
+ * the user space vhost client to set the number of descriptors in the virtio
+ * ring.
+ *
+ * Returns 0 on success, -1 otherwise.
+ */
+static int
+vr_uvhm_set_ring_num_desc(vr_uvh_client_t *vru_cl)
+{
+    VhostUserMsg *vum_msg;
+    unsigned int vring_idx;
+
+    vum_msg = &vru_cl->vruc_msg;
+    vring_idx = vum_msg->state.index;
+
+    if (vring_idx >= VHOST_CLIENT_MAX_VRINGS) {
+        vr_uvhost_log("Bad ring index %d received by vhost server\n",
+                      vring_idx);
+        return -1;
+    }
+
+    if (vr_dpdk_set_ring_num_desc(vru_cl->vruc_idx, vring_idx,
+                                  vum_msg->state.num)) {
+        vr_uvhost_log("Could set number of vring descriptors in vhost server"
+                      " %d %d %d\n",
+                      vru_cl->vruc_idx, vring_idx,
+                      vum_msg->state.num);
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
+ * vr_uvhm_map_addr - map a virtual address sent by the vhost client into
+ * a server virtual address.
+ *
+ * Returns a pointer to teh corresponding location on success, NULL otherwise.
+ */
+static void *
+vr_uvhm_map_addr(vr_uvh_client_t *vru_cl, uint64_t addr)
+{
+    int i;
+    uint64_t vmr_addr, vmr_size, ret_addr;
+
+    for (i = 0; i < vru_cl->vruc_num_mem_regions; i++) {
+        vmr_addr = vru_cl->vruc_mem_regions[i].vrucmr_user_space_addr;
+        vmr_size = vru_cl->vruc_mem_regions[i].vrucmr_size;
+
+        if ((vmr_addr <= addr) && (addr < (vmr_addr + vmr_size))) {
+             ret_addr = vru_cl->vruc_mem_regions[i].vrucmr_mmap_addr +
+                        (addr - vmr_addr);
+             return (void *) ret_addr;
+        }
+    }
+
+    return NULL;
+}
+
+/*
+ * vr_uvhm_set_vring_addr - handles a VHOST_USER_SET_VRING_ADDR message from
+ * the user space vhost client to set the address of the virtio rings.
+ *
+ * Returns 0 on success, -1 otherwise.
+ */
+static int
+vr_uvhm_set_vring_addr(vr_uvh_client_t *vru_cl)
+{
+    struct vhost_vring_addr *vaddr;
+    unsigned int vring_idx;
+    struct vring_desc *vrucv_desc;
+    struct vring_avail *vrucv_avail;
+    struct vring_used *vrucv_used;
+
+    vaddr = &vru_cl->vruc_msg.addr;
+
+    vring_idx = vaddr->index;
+    if (vring_idx >= VHOST_CLIENT_MAX_VRINGS) {
+        vr_uvhost_log("Bad ring index %d received by vhost server\n",
+                      vring_idx);
+        return -1;
+    }
+
+    vrucv_desc = (struct vring_desc *)
+        vr_uvhm_map_addr(vru_cl, vaddr->desc_user_addr);
+    vrucv_avail = (struct vring_avail *)
+        vr_uvhm_map_addr(vru_cl, vaddr->avail_user_addr);
+    vrucv_used = (struct vring_used *)
+        vr_uvhm_map_addr(vru_cl, vaddr->used_user_addr);
+
+    if (!vrucv_desc || !vrucv_avail || !vrucv_used)
+        return -1;
+
+    if (vr_dpdk_set_vring_addr(vru_cl->vruc_idx, vring_idx, vrucv_desc,
+                               vrucv_avail, vrucv_used)) {
+        vr_uvhost_log("Couldn't set vring addresses in vhost server, %d %d\n",
+                      vru_cl->vruc_idx, vring_idx);
+        return -1;
+    }
+
+    /*
+     * Now that the addresses have been set, the virtio queue is ready for
+     * forwarding.
+     *
+     * TODO - need a memory barrier here. Also , queue may need to be set to
+     * READY after callfd is set.
+     */
+    if (vr_dpdk_set_virtq_ready(vru_cl->vruc_idx, vring_idx, VQ_READY)) {
+        vr_uvhost_log("Couldn't set virtio queue ready in vhost server, "
+                      "%d %d\n",
+                      vru_cl->vruc_idx, vring_idx);
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
+ * vr_uvhm_set_vring_base - handles a VHOST_USER_SET_VRING_BASE messsage
+ * from the vhost user client to set the based index of a vring.
+ *
+ * Returns 0 on success, -1 otherwise.
+ */
+static int
+vr_uvhm_set_vring_base(vr_uvh_client_t *vru_cl)
+{
+    VhostUserMsg *vum_msg;
+    unsigned int vring_idx;
+
+    vum_msg = &vru_cl->vruc_msg;
+    vring_idx = vum_msg->state.index;
+
+    if (vring_idx >= VHOST_CLIENT_MAX_VRINGS) {
+        vr_uvhost_log("Bad ring index %d received by vhost server\n",
+                      vring_idx);
+        return -1;
+    }
+
+    if (vr_dpdk_virtio_set_vring_base(vru_cl->vruc_idx, vring_idx,
+                                      vum_msg->state.num)) {
+        vr_uvhost_log("Couldn't set vring base in vhost server %d %d %d\n",
+                      vru_cl->vruc_idx, vring_idx, vum_msg->state.num);
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
+ * vr_uvhm_get_vring_base - handles a VHOST_USER_GET_VRING_BASE messsage
+ * from the vhost user client to get the base index of a vring.
+ *
+ * Returns 0 on success, -1 otherwise.
+ */
+static int
+vr_uvhm_get_vring_base(vr_uvh_client_t *vru_cl)
+{
+    VhostUserMsg *vum_msg;
+    unsigned int vring_idx;
+
+    vum_msg = &vru_cl->vruc_msg;
+    vring_idx = vum_msg->state.index;
+
+    if (vring_idx >= VHOST_CLIENT_MAX_VRINGS) {
+        vr_uvhost_log("Bad ring index %d received by vhost server\n",
+                      vring_idx);
+        return -1;
+    }
+
+    if (vr_dpdk_virtio_get_vring_base(vru_cl->vruc_idx, vring_idx,
+                                     &vum_msg->state.num)) {
+        vr_uvhost_log("Couldn't get vring base in vhost server %d %d\n",
+                      vru_cl->vruc_idx, vring_idx);
+        return -1;
+    }
+
+    vum_msg->size = sizeof(struct vhost_vring_state);
+
+    return 0;
+}
+
+/*
+ * vr_uvhm_set_call_fd - handles a VHOST_USER_SET_VRING_CALL messsage
+ * from the vhost user client to set the eventfd to be used to interrupt the
+ * guest, if required.
+ *
+ * Returns 0 on success, -1 otherwise.
+ */
+static int
+vr_uvhm_set_call_fd(vr_uvh_client_t *vru_cl)
+{
+    VhostUserMsg *vum_msg;
+    unsigned int vring_idx;
+
+    vum_msg = &vru_cl->vruc_msg;
+    vring_idx = vum_msg->state.index;
+
+    if (vring_idx >= VHOST_CLIENT_MAX_VRINGS) {
+        vr_uvhost_log("Bad ring index %d received by vhost server in callfd\n",
+                      vring_idx);
+        return -1;
+    }
+
+    if (vr_dpdk_set_ring_callfd(vru_cl->vruc_idx, vring_idx,
+                                vru_cl->vruc_fds_sent[0])) {
+        vr_uvhost_log("Could not set callfd in vhost server"
+                      " %d %d %d\n",
+                      vru_cl->vruc_idx, vring_idx,
+                      vru_cl->vruc_fds_sent[0]);
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
+ * vr_uvh_cl_call_handler - calls message specific handler for messages
+ * from user space vhost client.
+ *
+ * Returns 0 on success, -1 otherwise.
+ */
+static int
+vr_uvh_cl_call_handler(vr_uvh_client_t *vru_cl)
+{
+    VhostUserMsg *msg = &vru_cl->vruc_msg;
+
+    if ((msg->request <= VHOST_USER_NONE) ||
+            (msg->request >= VHOST_USER_MAX)) {
+        return -1;
+    }
+
+    if (vr_uvhost_cl_msg_handlers[msg->request]) {
+        vr_uvhost_log("Calling handler for message %d\n", msg->request);
+        return vr_uvhost_cl_msg_handlers[msg->request](vru_cl);
+    } else {
+        vr_uvhost_log("No handler defined for message %d\n", msg->request);
+    }
+
+    return 0;
+}
+
+/*
+ * vr_uvh_cl_send_reply - send a reply to the vhost user client if
+ * required.
+ *
+ * Returns 0 on success, -1 otherwise.
+ */
+static int
+vr_uvh_cl_send_reply(vr_uvh_client_t *vru_cl)
+{
+    int ret;
+    VhostUserMsg *msg = &vru_cl->vruc_msg;
+
+    switch(msg->request) {
+        case VHOST_USER_GET_FEATURES:
+        case VHOST_USER_GET_VRING_BASE:
+            /*
+             * Send reply for these messages only.
+             */
+            msg->flags &= (~VHOST_USER_VERSION_MASK);
+            msg->flags |= VHOST_USER_VERSION;
+            msg->flags |= VHOST_USER_REPLY_MASK;
+
+            ret = send(vru_cl->vruc_fd, (void *) msg,
+                       VHOST_USER_HSIZE + msg->size, MSG_DONTWAIT);
+            if ((ret < 0) || (ret != (VHOST_USER_HSIZE + msg->size))) {
+                /*
+                 * TODO - handle EAGAIN/EWOULDBLOCK
+                 */
+                vr_uvhost_log("Error sending vhost user reply to %s\n",
+                              vru_cl->vruc_path);
+                return -1;
+             }
+
+            break;
+
+        default:
+            /*
+             * No reply needed.
+             */
+            break;
+    }
+
+    return 0;
+}
+
+/*
+ * vr_uvh_cl_msg_handler - handler for messages from user space vhost
+ * clients. Calls the appropriate handler based on the message type.
+ *
+ * Returns 0 on success, -1 on error.
+ *
+ * TODO: upon error, this function currently makes the process exit.
+ * Instead, it should close the socket and continue serving other clients.
+ */
+static int
+vr_uvh_cl_msg_handler(int fd, void *arg)
+{
+    vr_uvh_client_t *vru_cl = (vr_uvh_client_t *) arg;
+    struct msghdr mhdr;
+    struct iovec iov;
+    int ret, read_len = 0;
+    struct cmsghdr *cmsg;
+
+    memset(&mhdr, 0, sizeof(mhdr));
+
+    if (vru_cl->vruc_msg_bytes_read == 0) {
+        mhdr.msg_control = &vru_cl->vruc_cmsg;
+        mhdr.msg_controllen = sizeof(vru_cl->vruc_cmsg);
+
+        iov.iov_base = (void *) &vru_cl->vruc_msg;
+        iov.iov_len = VHOST_USER_HSIZE;
+
+        mhdr.msg_iov = &iov;
+        mhdr.msg_iovlen = 1;
+
+        ret = recvmsg(fd, &mhdr, MSG_DONTWAIT);
+        if (ret < 0) {
+            if ((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
+                return 0;
+            }
+
+            vr_uvhost_log("Receive returned %d in vhost server for client %s\n",
+                          ret, vru_cl->vruc_path);
+            return -1;
+        } else if (ret > 0) {
+            if (mhdr.msg_flags & MSG_CTRUNC) {
+                vr_uvhost_log("Truncated control message from vhost client %s\n",
+                             vru_cl->vruc_path);
+                return -1;
+            }
+
+            cmsg = CMSG_FIRSTHDR(&mhdr);
+            if (cmsg && (cmsg->cmsg_len > 0) &&
+                   (cmsg->cmsg_level == SOL_SOCKET) &&
+                   (cmsg->cmsg_type == SCM_RIGHTS)) {
+                   vru_cl->vruc_num_fds_sent = (cmsg->cmsg_len - CMSG_LEN(0))/
+                                                   sizeof(int);
+                   if (vru_cl->vruc_num_fds_sent > VHOST_MEMORY_MAX_NREGIONS) {
+                       vru_cl->vruc_num_fds_sent = VHOST_MEMORY_MAX_NREGIONS;
+                   }
+
+                   memcpy(vru_cl->vruc_fds_sent, CMSG_DATA(cmsg),
+                          vru_cl->vruc_num_fds_sent*sizeof(int));
+            }
+
+            vru_cl->vruc_msg_bytes_read = ret;
+            if (ret < VHOST_USER_HSIZE) {
+                return 0;
+            }
+
+            read_len = vru_cl->vruc_msg.size;
+        } else {
+            /*
+             * recvmsg returned 0, so return error.
+             */
+            vr_uvhost_log("Receive returned %d in vhost server for client %s\n",
+                          ret, vru_cl->vruc_path);
+            return -1;
+        }
+    } else if (vru_cl->vruc_msg_bytes_read < VHOST_USER_HSIZE) {
+        read_len = VHOST_USER_HSIZE - vru_cl->vruc_msg_bytes_read;
+    } else {
+        read_len = vru_cl->vruc_msg.size -
+                       (vru_cl->vruc_msg_bytes_read - VHOST_USER_HSIZE);
+    }
+
+    if (read_len) {
+        ret = read(fd, (((char *)&vru_cl->vruc_msg) + vru_cl->vruc_msg_bytes_read),
+                   read_len);
+        if (ret < 0) {
+            if ((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
+                return 0;
+            }
+
+            vr_uvhost_log(
+                "Read returned %d, %d %d %d in vhost server for client %s\n",
+                ret, errno, read_len,
+                vru_cl->vruc_msg_bytes_read, vru_cl->vruc_path);
+            return -1;
+        } else if (ret == 0) {
+             vr_uvhost_log("Read returned %d in vhost server for client %s\n",
+                           ret, vru_cl->vruc_path);
+            return -1;
+        }
+
+        vru_cl->vruc_msg_bytes_read += ret;
+        if (vru_cl->vruc_msg_bytes_read < VHOST_USER_HSIZE) {
+            return 0;
+        }
+
+        if (vru_cl->vruc_msg_bytes_read <
+                (vru_cl->vruc_msg.size + VHOST_USER_HSIZE)) {
+            return 0;
+        }
+    }
+
+    ret = vr_uvh_cl_call_handler(vru_cl);
+    if (ret < 0) {
+        vr_uvhost_log("Error calling message handler for client %s\n",
+                      vru_cl->vruc_path);
+        return -1;
+    }
+
+    ret = vr_uvh_cl_send_reply(vru_cl);
+    if (ret < 0) {
+        vr_uvhost_log("Error sending reply to vhost client %s\n",
+                      vru_cl->vruc_path);
+        return -1;
+    }
+
+    /*
+     * Message received successully, so clear state for next message from
+     * this client.
+     */
+    vru_cl->vruc_msg_bytes_read = 0;
+    memset(&vru_cl->vruc_msg, 0, sizeof(vru_cl->vruc_msg));
+    memset(vru_cl->vruc_cmsg, 0, sizeof(vru_cl->vruc_cmsg));
+    memset(vru_cl->vruc_fds_sent, 0, sizeof(vru_cl->vruc_fds_sent));
+    vru_cl->vruc_num_fds_sent = 0;
+
+    return 0;
+}
+
+/*
+ * vr_uvh_cl_listen_handler - handler for connections from user space vhost
+ * clients. Accepts the connections and sets up a message handler for the
+ * client in the server.
+ *
+ * Returns 0 on success, -1 otherwise.
+ */
+static int
+vr_uvh_cl_listen_handler(int fd, void *arg)
+{
+    int s = 0;
+    struct sockaddr_un sun;
+    socklen_t len = sizeof(sun);
+    vr_uvh_client_t *vru_cl = (vr_uvh_client_t *) arg;
+
+    vr_uvhost_log("Handling client connection FD %d\n", fd);
+    s = accept(fd, (struct sockaddr *) &sun, &len);
+    if (s < 0) {
+        if ((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
+            return 0;
+        }
+
+        vr_uvhost_log("\terror accepting client connection FD %d\n", fd);
+        return -1;
+    }
+
+    /*
+     * Don't need to listen on the socket any more.
+     */
+    vr_uvhost_del_fd(fd, UVH_FD_READ);
+    vr_uvhost_cl_set_fd(vru_cl, s);
+
+    if (vr_uvhost_add_fd(s, UVH_FD_READ, vru_cl, vr_uvh_cl_msg_handler)) {
+        vr_uvhost_log("\terror adding client %s FD %d read handler\n",
+                      sun.sun_path, fd);
+        goto error;
+    }
+
+    return 0;
+
+error:
+
+    if (s) {
+        close(s);
+    }
+
+    if (vru_cl) {
+        vr_uvhost_del_client(vru_cl);
+    }
+
+    return -1;
+}
+
+/*
+ * vr_uvh_nl_vif_del_handler - handle a message from the netlink thread
+ * to delete a vif.
+ *
+ * Returns 0 on success, -1 otherwise.
+ */
+int
+vr_uvh_nl_vif_del_handler(vrnu_vif_del_t *msg)
+{
+    unsigned int cidx = msg->vrnu_vif_idx;
+    vr_uvh_client_t *vru_cl;
+
+    if (cidx >= VR_UVH_MAX_CLIENTS) {
+        vr_uvhost_log("Couldn't delete vhost client due to bad index %d\n",
+                      cidx);
+        return -1;
+    }
+
+    vr_dpdk_virtio_set_vif_client(cidx, NULL);
+
+    vru_cl = vr_uvhost_get_client(cidx);
+    if (vru_cl == NULL) {
+        vr_uvhost_log("Couldn't find vhost client %d for deletion\n",
+                      cidx);
+        return -1;
+    }
+
+    if (vru_cl->vruc_fd != -1) {
+        vr_uvhost_del_fd(vru_cl->vruc_fd, UVH_FD_READ);
+    }
+
+    vru_cl->vruc_fd = -1;
+
+    return 0;
+}
+
+
+/*
+ * vr_uvh_nl_vif_add_handler - handle a vif add message from the netlink
+ * thread. In response, the vhost server thread starts listening on the
+ * UNIX domain socket corresponding to this vif.
+ *
+ * Returns 0 on success, -1 otherwise.
+ */
+static int
+vr_uvh_nl_vif_add_handler(vrnu_vif_add_t *msg)
+{
+    int s = 0, ret = -1;
+    struct sockaddr_un sun;
+    int flags;
+    vr_uvh_client_t *vru_cl = NULL;
+    mode_t umask_mode;
+
+    if (msg == NULL) {
+        vr_uvhost_log("\terror adding vif: message is NULL\n");
+        return -1;
+    }
+
+    vr_uvhost_log("NetLink adding vif %s...\n", msg->vrnu_vif_name);
+    s = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (s == -1) {
+        vr_uvhost_log("\terror creating socket: %s (%d)\n",
+                        strerror(errno), errno);
+        goto error;
+    }
+    vr_uvhost_log("\tvif %s socket FD is %d\n", msg->vrnu_vif_name, s);
+
+    memset(&sun, 0, sizeof(sun));
+    strncpy(sun.sun_path, VR_UVH_VIF_PREFIX, sizeof(sun.sun_path) - 1);
+    strncat(sun.sun_path, msg->vrnu_vif_name,
+        sizeof(sun.sun_path) - strlen(sun.sun_path) - 1);
+    sun.sun_family = AF_UNIX;
+
+    unlink(sun.sun_path);
+
+    /*
+     * Ensure RW permissions for the socket files such that QEMU process is
+     * able to connect.
+     */
+    umask_mode = umask(~(S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH |
+            S_IWOTH));
+
+    ret = bind(s, (struct sockaddr *) &sun, sizeof(sun));
+    if (ret == -1) {
+        vr_uvhost_log("\terror binding FD %d to %s: %s (%d)\n",
+                      s, sun.sun_path, strerror(errno), errno);
+        goto error;
+    }
+
+    umask(umask_mode);
+
+    /*
+     * Set the socket to non-blocking
+     */
+    flags = fcntl(s, F_GETFL, 0);
+    fcntl(s, flags | O_NONBLOCK);
+
+    ret = listen(s, 1);
+    if (ret == -1) {
+        vr_uvhost_log("\terror listening socket FD %d: %s (%d)\n",
+                        s, strerror(errno), errno);
+        goto error;
+    }
+
+    vru_cl = vr_uvhost_new_client(s, sun.sun_path, msg->vrnu_vif_idx);
+    if (vru_cl == NULL) {
+        vr_uvhost_log("\terror creating socket %s new vhost client\n",
+                      sun.sun_path);
+        goto error;
+    }
+
+    vru_cl->vruc_idx = msg->vrnu_vif_idx;
+    vru_cl->vruc_nrxqs = msg->vrnu_vif_nrxqs;
+    vru_cl->vruc_ntxqs = msg->vrnu_vif_ntxqs;
+
+    ret = vr_uvhost_add_fd(s, UVH_FD_READ, vru_cl, vr_uvh_cl_listen_handler);
+    if (ret == -1) {
+        vr_uvhost_log("\terror adding socket FD %d\n", s);
+        goto error;
+    }
+
+    vr_dpdk_virtio_set_vif_client(msg->vrnu_vif_idx, vru_cl);
+
+    return 0;
+
+error:
+
+    if (s) {
+        close(s);
+    }
+
+    if (vru_cl) {
+        vr_uvhost_del_client(vru_cl);
+    }
+
+    return ret;
+}
+
+
+/*
+ * vr_uvh_nl_msg_handler - handles messages received form the netlink
+ * thread. This is usually to convey the name of the UNIX domain socket
+ * that the user space vhost server should listen on for connections from
+ * qemu.
+ *
+ * Returns 0 on success, -1 otherwise.
+ */
+static int
+vr_uvh_nl_msg_handler(int fd, void *arg)
+{
+    vrnu_msg_t msg;
+    int ret;
+
+    ret = recv(fd, (void *) &msg, sizeof(msg), MSG_DONTWAIT);
+    if (ret < 0) {
+        if ((errno != EAGAIN) && (errno != EWOULDBLOCK)) {
+            vr_uvhost_log("Error %d in netlink msg receive in vhost server\n",
+                          errno);
+            return ret;
+        } else {
+            return 0;
+        }
+    }
+
+    if (ret != sizeof(msg)) {
+        vr_uvhost_log("Received msg of length %d, expected %d in vhost server",
+                      ret, sizeof(msg));
+        return -1;
+    }
+
+    switch (msg.vrnum_type) {
+        case VRNU_MSG_VIF_ADD:
+            ret = vr_uvh_nl_vif_add_handler(&msg.vrnum_vif_add);
+            break;
+
+        case VRNU_MSG_VIF_DEL:
+            ret = vr_uvh_nl_vif_del_handler(&msg.vrnum_vif_del);
+            break;
+
+        default:
+            vr_uvhost_log("Unknown netlink msg %d received in vhost server\n",
+                          msg.vrnum_type);
+            ret = -1;
+            break;
+    }
+
+    return ret;
+}
+
+/*
+ * vr_uvh_nl_listen_handler - handles conenctions from the netlink
+ * thread.
+ *
+ * Returns 0 on success, -1 otherwise.
+ */
+int
+vr_uvh_nl_listen_handler(int fd, void *arg)
+{
+    int s;
+    struct sockaddr_un sun;
+    socklen_t len = sizeof(sun);
+
+    vr_uvhost_log("Handling NetLink connection FD %d...\n", fd);
+    s = accept(fd, (struct sockaddr *) &sun, &len);
+    if (s < 0) {
+        vr_uvhost_log("\terror accepting NetLink connection FD %d\n", fd);
+        return -1;
+    }
+
+    if (vr_uvhost_add_fd(s, UVH_FD_READ, NULL, vr_uvh_nl_msg_handler)) {
+        vr_uvhost_log("\terror adding NetLink %s FD %d read handler\n",
+                      sun.sun_path, fd);
+        return -1;
+    }
+
+    return 0;
+}

--- a/dpdk/vr_uvhost_msg.c
+++ b/dpdk/vr_uvhost_msg.c
@@ -23,6 +23,7 @@
 #include "qemu_uvhost.h"
 #include "vr_uvhost_client.h"
 #include "vr_dpdk_virtio.h"
+#include "vr_dpdk_usocket.h"
 
 typedef int (*vr_uvh_msg_handler_fn)(vr_uvh_client_t *vru_cl);
 
@@ -678,6 +679,7 @@ vr_uvh_nl_vif_add_handler(vrnu_vif_add_t *msg)
         sizeof(sun.sun_path) - strlen(sun.sun_path) - 1);
     sun.sun_family = AF_UNIX;
 
+    mkdir(VR_SOCKET_DIR, VR_SOCKET_DIR_MODE);
     unlink(sun.sun_path);
 
     /*

--- a/dpdk/vr_uvhost_msg.h
+++ b/dpdk/vr_uvhost_msg.h
@@ -12,7 +12,7 @@
  * user space vhost thread
  */
 
-#define VR_UVH_VIF_PREFIX "/tmp/uvh_vif_"
+#define VR_UVH_VIF_PREFIX VR_SOCKET_DIR"/uvh_vif_"
 #define VHOST_USER_VERSION 1
 
 typedef enum vrnu_msg_type {

--- a/dpdk/vr_uvhost_msg.h
+++ b/dpdk/vr_uvhost_msg.h
@@ -1,0 +1,45 @@
+/*
+ * vr_uvhost_msg.h - header for handlers for messages received by the user space
+ * vhost thread.
+ *
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+#ifndef __VR_UVHOST_MSG_H__
+#define __VR_UVHOST_MSG_H__
+
+/*
+ * Definitions of messages from the netlink thread that are handled by the
+ * user space vhost thread
+ */
+
+#define VR_UVH_VIF_PREFIX "/tmp/uvh_vif_"
+#define VHOST_USER_VERSION 1
+
+typedef enum vrnu_msg_type {
+    VRNU_MSG_VIF_ADD = 1,
+    VRNU_MSG_VIF_DEL,
+    VRNU_MSG_MAX
+} vrnu_msg_type_t;
+
+typedef struct vrnu_vif_add {
+    char vrnu_vif_name[VR_INTERFACE_NAME_LEN];
+    unsigned int vrnu_vif_idx;
+    unsigned int vrnu_vif_nrxqs;
+    unsigned int vrnu_vif_ntxqs;
+} vrnu_vif_add_t;
+
+typedef struct vrnu_vif_del {
+    unsigned int vrnu_vif_idx;
+} vrnu_vif_del_t;
+
+typedef struct vrnu_msg {
+    vrnu_msg_type_t vrnum_type;
+    union {
+        vrnu_vif_add_t vrnum_vif_add;
+        vrnu_vif_del_t vrnum_vif_del;
+    };
+} vrnu_msg_t;
+
+int vr_uvh_nl_listen_handler(int fd, void *arg);
+
+#endif /* __VR_UVHOST_MSG_H__ */

--- a/dpdk/vr_uvhost_util.c
+++ b/dpdk/vr_uvhost_util.c
@@ -1,0 +1,271 @@
+/*
+ * vr_uvhost_util.c - utils for user-space vhost server that peers with
+ * the vhost client inside qemu (version 2.1 and later).
+ *
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+#include <stdarg.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/select.h>
+#include <pthread.h>
+
+#include "vr_dpdk.h"
+#include "vr_uvhost.h"
+#include "vr_uvhost_util.h"
+
+#define MAX_UVHOST_FDS 1024
+
+typedef struct uvh_fd_s {
+    int uvh_fd;
+    void *uvh_fd_arg;
+    uvh_fd_handler_t uvh_fd_fn;
+} uvh_fd_t;
+
+/* Global variables */
+static uvh_fd_t uvh_rfds[MAX_UVHOST_FDS];
+static uvh_fd_t uvh_wfds[MAX_UVHOST_FDS];
+static fd_set uvh_rfdset, uvh_wfdset;
+static int uvh_max_fd = 0;
+
+/*
+ * vr_uvhost_log - logs user space vhost messages to a file.
+ */
+void
+vr_uvhost_log(const char *format, ...)
+{
+    va_list ap;
+    FILE *f = stderr; /* TODO _ change to a different file */
+
+    fprintf(f, "UVHOST: ");
+    va_start(ap, format);
+    vfprintf(f, format, ap);
+    fflush(f);
+
+    return;
+}
+
+/*
+ * vr_uvhost_del_fd - deletes a FD from the read/write list that the
+ * user space vhost server is listening on. fd_type indicates if it
+ * is a read/write socket. The FD passed in will be closed.
+ *
+ * Returns 0 on success, -1 otherwise.
+ */
+int
+vr_uvhost_del_fd(int fd, uvh_fd_type_t fd_type)
+{
+    int i;
+    uvh_fd_t *fds;
+
+    RTE_LOG(DEBUG, VROUTER, "Deleting FD %d from the select pool...\n", fd);
+    if (fd_type == UVH_FD_READ) {
+        fds = uvh_rfds;
+    } else if (fd_type == UVH_FD_WRITE) {
+        fds = uvh_wfds;
+    } else {
+        return -1;
+    }
+
+    for (i = 0; i < MAX_UVHOST_FDS; i++) {
+        if (fds[i].uvh_fd == fd) {
+            break;
+        }
+    }
+
+    if (i == MAX_UVHOST_FDS) {
+        vr_uvhost_log("Error deleting FD %d: not found\n", fd);
+        return -1;
+    }
+
+    fds[i].uvh_fd = -1;
+    vr_uvh_recalc_max_fd();
+
+    close(fd);
+
+    return 0;
+}
+
+/*
+ * vr_uvhost_add_fd - adds the specified FD into the read/write list that
+ * the user space vhost server is waiting on. The type indicates if it
+ * is a read/write socket and the handler is the function that is called when
+ * there is an event on the socket.
+ *
+ * Returns 0 on success, -1 otherwise.
+ */
+int
+vr_uvhost_add_fd(int fd, uvh_fd_type_t fd_type, void *fd_handler_arg,
+                 uvh_fd_handler_t fd_handler)
+{
+    int i;
+    uvh_fd_t *fds;
+
+    RTE_LOG(DEBUG, VROUTER, "Adding FD %d to the select pool...\n", fd);
+    if (fd_type == UVH_FD_READ) {
+        fds = uvh_rfds;
+    } else if (fd_type == UVH_FD_WRITE) {
+        fds = uvh_wfds;
+    } else {
+        return -1;
+    }
+
+    for (i = 0; i < MAX_UVHOST_FDS; i++) {
+        if (fds[i].uvh_fd == -1) {
+            fds[i].uvh_fd = fd;
+            fds[i].uvh_fd_arg = fd_handler_arg;
+            fds[i].uvh_fd_fn = fd_handler;
+
+            if (fd > uvh_max_fd) {
+                uvh_max_fd = fd;
+            }
+
+            return 0;
+        }
+    }
+
+    vr_uvhost_log("Error adding FD %d: no space left\n", fd);
+
+    return -1;
+}
+
+/*
+ * vr_uvhost_fdset_init - initializes the read and write FD sets before
+ * we enter the select loop.
+ */
+void
+vr_uvhost_fdset_init(void)
+{
+    int i;
+
+    FD_ZERO(&uvh_rfdset);
+    FD_ZERO(&uvh_wfdset);
+
+    for (i = 0; i < MAX_UVHOST_FDS; i++) {
+        uvh_rfds[i].uvh_fd = -1;
+        uvh_wfds[i].uvh_fd = -1;
+    }
+
+    return;
+}
+
+/*
+ * vr_uvh_max_fd - returns the max FD for select.
+ */
+int
+vr_uvh_max_fd(void)
+{
+    return uvh_max_fd;
+}
+
+/*
+ * vr_uvh_recalc_max_fd - recalculates the max FD to -1.
+ */
+void
+vr_uvh_recalc_max_fd(void)
+{
+    int i;
+
+    uvh_max_fd = -1;
+    for (i = 0; i < MAX_UVHOST_FDS; i++) {
+        if (uvh_rfds[i].uvh_fd != -1
+            && uvh_rfds[i].uvh_fd > uvh_max_fd) {
+            uvh_max_fd = uvh_rfds[i].uvh_fd;
+        }
+        if (uvh_wfds[i].uvh_fd != -1
+            && uvh_wfds[i].uvh_fd > uvh_max_fd) {
+            uvh_max_fd = uvh_wfds[i].uvh_fd;
+        }
+    }
+}
+
+/*
+ * vr_uvh_rfdset_p - returns a pointer to the fdset corresponding to the
+ * read fds.
+ */
+fd_set *
+vr_uvh_rfdset_p(void)
+{
+    int i;
+
+    FD_ZERO(&uvh_rfdset);
+
+    for (i = 0; i < MAX_UVHOST_FDS; i++) {
+        if (uvh_rfds[i].uvh_fd == -1) {
+            continue;
+        }
+
+        FD_SET(uvh_rfds[i].uvh_fd, &uvh_rfdset);
+    }
+
+    return &uvh_rfdset;
+}
+
+/*
+ * vr_uvh_wfdset_p - returns a pointer to the write fdset.
+ */
+fd_set *
+vr_uvh_wfdset_p(void)
+{
+    int i;
+
+    FD_ZERO(&uvh_wfdset);
+
+    for (i = 0; i < MAX_UVHOST_FDS; i++) {
+        if (uvh_wfds[i].uvh_fd == -1) {
+            continue;
+        }
+
+        FD_SET(uvh_wfds[i].uvh_fd, &uvh_wfdset);
+    }
+
+    return &uvh_wfdset;
+}
+
+/*
+ * vr_uvh_call_fd_handlers_internal - internal function to call the handler
+ * for all fds that are set in the fd_set.
+ *
+ * Returns 0 on success, error FD otherwise.
+ */
+static int
+vr_uvh_call_fd_handlers_internal(uvh_fd_t *fd_arr, fd_set *fdset_ptr)
+{
+    int i, ret = 0;
+
+    for (i = 0; i < MAX_UVHOST_FDS; i++) {
+        if (fd_arr[i].uvh_fd == -1) {
+            continue;
+        }
+
+        if (FD_ISSET(fd_arr[i].uvh_fd, fdset_ptr)) {
+            ret = fd_arr[i].uvh_fd_fn(fd_arr[i].uvh_fd, fd_arr[i].uvh_fd_arg);
+            if (ret)
+                return fd_arr[i].uvh_fd;
+        }
+    }
+
+    return 0;
+}
+
+/*
+ * vr_uvh_call_fd_handlers - call the handler for each FD that is set upon
+ * return from select().
+ *
+ * Returns 0 on success, -1 otherwise.
+ */
+int
+vr_uvh_call_fd_handlers(void)
+{
+    int ret;
+
+    ret = vr_uvh_call_fd_handlers_internal(uvh_rfds, &uvh_rfdset);
+    if (ret)
+        vr_uvhost_del_fd(ret, UVH_FD_READ);
+
+    ret = vr_uvh_call_fd_handlers_internal(uvh_wfds, &uvh_wfdset);
+    if (ret)
+        vr_uvhost_del_fd(ret, UVH_FD_WRITE);
+
+    return 0;
+}

--- a/dpdk/vr_uvhost_util.h
+++ b/dpdk/vr_uvhost_util.h
@@ -1,0 +1,29 @@
+/*
+ * vr_uvhost_util.h - header for utils for user-space vhost server that peers
+ * with the vhost client inside qemu (version 2.1 and later).
+ *
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+
+#ifndef __VR_UVHOST_UTIL_H__
+#define __VR_UVHOST_UTIL_H__
+
+typedef int (*uvh_fd_handler_t)(int fd, void *arg);
+
+typedef enum uvh_fd_type {
+    UVH_FD_READ = 1,
+    UVH_FD_WRITE = 2
+} uvh_fd_type_t;
+
+void vr_uvhost_fdset_init(void);
+int vr_uvhost_add_fd(int fd, uvh_fd_type_t fd_type, void *fd_handler_arg,
+                     uvh_fd_handler_t fd_handler);
+int vr_uvhost_del_fd(int fd, uvh_fd_type_t fd_type);
+void vr_uvh_recalc_max_fd(void);
+void vr_uvhost_log(const char *format, ...);
+int vr_uvh_max_fd(void);
+fd_set *vr_uvh_rfdset_p(void);
+fd_set *vr_uvh_wfdset_p(void);
+int vr_uvh_call_fd_handlers(void);
+
+#endif /* __VR_UVHOST_UTIL_H__ */

--- a/host/vrouter_host_mod.c
+++ b/host/vrouter_host_mod.c
@@ -3,6 +3,8 @@
  *
  * Copyright (c) 2013 Juniper Networks, Inc. All rights reserved.
  */
+#include <stdarg.h>
+
 #include "vr_os.h"
 #include "vr_packet.h"
 #include "vr_proto.h"
@@ -18,9 +20,6 @@ unsigned int vr_num_cpus = 1;
 
 static bool vr_host_inited = false;
 static unsigned int vr_message_proto;
-
-extern int vr_flow_entries;
-extern int vr_oflow_entries;
 
 extern void vr_diet_message_proto_exit(void);
 extern int vr_diet_message_proto_init(void);
@@ -61,6 +60,19 @@ vr_lib_page_free(void *address, unsigned int size)
 {
 	if (address)
 		free(address);
+}
+
+static int
+vr_lib_printf(const char *format, ...)
+{
+    int printed;
+    va_list args;
+
+    va_start(args, format);
+    printed = printf(format, args);
+    va_end(args);
+
+    return printed;
 }
 
 static void *
@@ -220,6 +232,7 @@ vr_lib_delay_op(void)
 }
 
 struct host_os vr_lib_host = {
+    .hos_printf             =       vr_lib_printf,
     .hos_malloc             =       vr_lib_malloc,
     .hos_zalloc             =       vr_lib_zalloc,
     .hos_free               =       vr_lib_free,

--- a/include/host/vr_host_interface.h
+++ b/include/host/vr_host_interface.h
@@ -6,7 +6,7 @@
 #ifndef __HOST_VR_HOST_INTERFACE_H__
 #define __HOST_VR_HOST_INTERFACE_H__
 
-/* 
+/*
  * has to be a power of 2. increasing this will need some
  * more changes in the sources.
  */

--- a/include/ini_parser.h
+++ b/include/ini_parser.h
@@ -1,0 +1,41 @@
+/*
+ * ini_parser.h --
+ *
+ * Copyright (c) 2013 Juniper Networks, Inc. All rights reserved.
+ */
+#ifndef __INI_PARSER_H__
+#define __INI_PARSER_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define LINUX_PLATFORM  1
+#define DPDK_PLATFORM   2
+#define NIC_PLATFORM    3
+
+#define DEFAULT_SECTION "DEFAULT"
+#define PLATFORM_KEY    "platform"
+#define PLATFORM_DPDK   "dpdk"
+#define PLATFORM_NIC    "nic"
+
+extern int read_int(const char *section, const char *key);
+extern const char *read_string(const char *section, const char *key);
+extern uint32_t read_ip(const char *section, const char *key);
+
+extern int get_type(void);
+extern uint16_t get_port(void);
+extern uint32_t get_ip(void);
+
+extern int get_domain(void);
+extern int get_socket_type(void);
+extern int get_vrouter_ip(void);
+extern int get_platform(void);
+extern int get_protocol(void);
+
+extern int parse_ini_file(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* __INI_PARSER_H__ */

--- a/include/nl_util.h
+++ b/include/nl_util.h
@@ -46,6 +46,12 @@ struct nl_client {
     struct nl_response resp;
     unsigned int cl_resp_buf_len;
     uint8_t *cl_resp_buf;
+    int cl_socket_domain;
+    int cl_socket_type;
+    int cl_socket_proto;
+    struct sockaddr *cl_sa;
+    uint32_t cl_sa_len;
+    int (*cl_recvmsg)(struct nl_client *);
 };
 
 
@@ -62,8 +68,11 @@ struct genl_ctrl_message {
 
 extern struct nl_client *nl_register_client(void);
 extern void nl_free_client(struct nl_client *cl);
-extern int nl_socket(struct nl_client *, unsigned int);
+extern int nl_socket(struct nl_client *, int, int , int);
+extern int nl_connect(struct nl_client *, uint32_t, uint16_t);
 extern int nl_sendmsg(struct nl_client *);
+extern int nl_client_datagram_recvmsg(struct nl_client *);
+extern int nl_client_stream_recvmsg(struct nl_client *);
 extern int nl_recvmsg(struct nl_client *);
 extern struct nl_response *nl_parse_reply(struct nl_client *);
 extern struct nl_response *nl_parse_gen_nh(struct nl_client *);
@@ -92,6 +101,7 @@ extern uint8_t *nl_get_buf_ptr(struct nl_client *cl);
 extern uint32_t nl_get_buf_len(struct nl_client *cl);
 extern void nl_build_attr(struct nl_client *cl, int len, int attr);
 extern int vrouter_get_family_id(struct nl_client *cl);
+extern int get_vrouter_pid(void);
 
 #ifdef __cplusplus
 }

--- a/include/ulinux.h
+++ b/include/ulinux.h
@@ -4,26 +4,26 @@
 #include <time.h>
 
 struct list_head {
-	struct list_head *next, *prev;
+    struct list_head *next, *prev;
 };
 
 struct dummy_timer_list {
-        /*
- * All fields that change during normal runtime grouped to the
- * same cacheline
- */
-	struct list_head entry;
-	unsigned long expires;
-	struct tvec_base *base;
+    /*
+     * All fields that change during normal runtime grouped to the
+     * same cacheline
+     */
+    struct list_head entry;
+    unsigned long expires;
+    struct tvec_base *base;
 
-	void (*function)(unsigned long);
-	unsigned long data;
+    void (*function)(unsigned long);
+    unsigned long data;
 
-	int slack;
+    int slack;
 
-	int start_pid;
-	void *start_site;
-	char start_comm[16];
+    int start_pid;
+    void *start_site;
+    char start_comm[16];
 };
 
 time_t get_time(void);

--- a/include/vr_bridge.h
+++ b/include/vr_bridge.h
@@ -35,7 +35,7 @@
      (((uint16_t *)dst)[2] == 0xffff))  \
 
 #define IS_MAC_BMCAST(dst) \
-     (((uint8_t *)dst)[0]& 0x1) 
+     (((uint8_t *)dst)[0]& 0x1)
 
 #define VR_BE_INVALID_INDEX              ((unsigned int)-1)
 

--- a/include/vr_btable.h
+++ b/include/vr_btable.h
@@ -1,12 +1,14 @@
 /*
- * vr_btable.h -- 
+ * vr_btable.h --
  *
  * Copyright (c) 2013 Juniper Networks, Inc. All rights reserved.
  */
 #ifndef __VR_BTABLE_H__
 #define __VR_BTABLE_H__
 
-#define VR_SINGLE_ALLOC_LIMIT   (4  * 1024 * 1024)
+#define VB_FLAG_MEMORY_ATTACHED 0x1
+
+#define VR_SINGLE_ALLOC_LIMIT   (4 * 1024 * 1024)
 
 struct vr_btable_partition {
     unsigned int vb_offset;
@@ -17,6 +19,8 @@ struct vr_btable {
     unsigned int    vb_entries;
     unsigned short  vb_esize;
     unsigned short  vb_partitions;
+    unsigned int    vb_flags;
+    unsigned int    vb_alloc_limit;
     void            **vb_mem;
     struct vr_btable_partition *vb_table_info;
 };
@@ -27,6 +31,7 @@ void *vr_btable_get_address(struct vr_btable *, unsigned int);
 
 void vr_btable_free(struct vr_btable *);
 struct vr_btable *vr_btable_alloc(unsigned int, unsigned int);
+struct vr_btable *vr_btable_attach(struct iovec *, unsigned int, unsigned short);
 
 static inline unsigned int
 vr_btable_entries(struct vr_btable *table)
@@ -48,8 +53,8 @@ vr_btable_get(struct vr_btable *table, unsigned int entry)
     if (entry >= table->vb_entries)
         return NULL;
 
-    t_index = (entry * table->vb_esize) / VR_SINGLE_ALLOC_LIMIT;
-    t_offset = (entry * table->vb_esize) % VR_SINGLE_ALLOC_LIMIT;
+    t_index = (entry * table->vb_esize) / table->vb_alloc_limit;
+    t_offset = (entry * table->vb_esize) % table->vb_alloc_limit;
     if (t_index >= table->vb_partitions)
         return NULL;
 

--- a/include/vr_compat.h
+++ b/include/vr_compat.h
@@ -1,14 +1,14 @@
 /*
- *  vr_compat.h - compatibility definitions
- *  
- *  Copyright (c) 2013 Juniper Networks, Inc. All rights reserved.
+ * vr_compat.h - compatibility definitions
+ *
+ * Copyright (c) 2013 Juniper Networks, Inc. All rights reserved.
  */
 
 #ifndef __VRCOMPAT_H__
 #define __VRCOMPAT_H__
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3,3,0))
-#if (! (defined(RHEL_MAJOR) && defined(RHEL_MINOR)  && \
+#if (! (defined(RHEL_MAJOR) && defined(RHEL_MINOR) && \
            (RHEL_MAJOR == 6) && (RHEL_MINOR >= 5)))
 typedef u64 netdev_features_t;
 #endif
@@ -37,7 +37,7 @@ skb_get_rxhash(struct sk_buff *skb)
 static inline __u32
 skb_get_rxhash(struct sk_buff *skb)
 {
-#if defined(RHEL_MAJOR) && defined(RHEL_MINOR)  && \
+#if defined(RHEL_MAJOR) && defined(RHEL_MINOR) && \
            (RHEL_MAJOR == 6) && (RHEL_MINOR == 4)
     struct iphdr *ip;
     u32 ports = 0;
@@ -105,26 +105,26 @@ static inline void skb_frag_size_sub(skb_frag_t *frag, int delta)
 {
         frag->size -= delta;
 }
-    
+
 #endif
-    
+
 #endif
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(2,6,39))
 enum rx_handler_result {
-	RX_HANDLER_CONSUMED,
-	RX_HANDLER_ANOTHER,
-	RX_HANDLER_EXACT,
-	RX_HANDLER_PASS,
+    RX_HANDLER_CONSUMED,
+    RX_HANDLER_ANOTHER,
+    RX_HANDLER_EXACT,
+    RX_HANDLER_PASS,
 };
 
 typedef enum rx_handler_result rx_handler_result_t;
 
-#define VLAN_CFI_MASK    0x1000
-#define VLAN_TAG_PRESENT VLAN_CFI_MASK
-#define ARPHRD_VOID    0xFFFF
+#define VLAN_CFI_MASK       0x1000
+#define VLAN_TAG_PRESENT    VLAN_CFI_MASK
+#define ARPHRD_VOID         0xFFFF
 
-#if (RHEL_MAJOR != 6) && (RHEL_MINOR != 4) 
+#if (RHEL_MAJOR != 6) && (RHEL_MINOR != 4)
 
 #define alloc_netdev_mqs(sizeof_priv, name, setup, count1, count2) \
         alloc_netdev_mq(sizeof_priv, name, setup, count1)
@@ -137,7 +137,7 @@ static inline void skb_reset_mac_len(struct sk_buff *skb)
 #endif
 
 #ifndef ISRHOSKERNEL
-#if (! (defined(RHEL_MAJOR) && defined(RHEL_MINOR)  && \
+#if (! (defined(RHEL_MAJOR) && defined(RHEL_MINOR) && \
            (RHEL_MAJOR == 6) && (RHEL_MINOR >= 5)))
 static bool can_checksum_protocol(netdev_features_t features, __be16 protocol)
 {

--- a/include/vr_defs.h
+++ b/include/vr_defs.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * vr_defs.h - definitions
  *
  * Copyright (c) 2013 Juniper Networks, Inc. All rights reserved.
@@ -60,7 +60,7 @@ struct agent_hdr {
     unsigned int hdr_cmd_param;
     unsigned int hdr_cmd_param_1;
 } __attribute__((packed));
-    
+
 #define CMD_PARAM_PACKET_CTRL       0x1
 #define CMD_PARAM_1_DIAG            0x1
 #define MAX_CMD_PARAMS                3

--- a/include/vr_dpdk.h
+++ b/include/vr_dpdk.h
@@ -1,0 +1,507 @@
+/*
+ * Copyright (C) 2014 Semihalf.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation version 2.
+ *
+ * This program is distributed "as is" WITHOUT ANY WARRANTY of any
+ * kind, whether express or implied; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * vr_dpdk.h -- vRouter/DPDK definitions
+ *
+ */
+
+#ifndef _VR_DPDK_H_
+#define _VR_DPDK_H_
+
+#include <net/if.h>
+#include <sys/queue.h>
+
+#include "vr_os.h"
+#include "vr_packet.h"
+#include "vr_interface.h"
+
+#include <rte_config.h>
+#include <rte_pci.h>
+#include <rte_version.h>
+#include <rte_kni.h>
+#include <rte_ethdev.h>
+#include <rte_port.h>
+
+#define RTE_LOGTYPE_VROUTER         RTE_LOGTYPE_USER1
+#undef RTE_LOG_LEVEL
+#define RTE_LOG_LEVEL               RTE_LOG_INFO
+/*
+ * Debug options:
+ *
+#define RTE_LOG_LEVEL               RTE_LOG_DEBUG
+#define VR_DPDK_NETLINK_DEBUG
+#define VR_DPDK_NETLINK_PKT_DUMP
+#define VR_DPDK_RX_PKT_DUMP
+#define VR_DPDK_TX_PKT_DUMP
+ */
+
+/* lcore mask */
+#define VR_DPDK_LCORE_MASK          0x3f
+/* Number of service lcores */
+#define VR_DPDK_NB_SERVICE_LCORES   2
+/* Minimum number of lcores */
+#define VR_DPDK_MIN_LCORES          2
+/* Memory to allocate at startup in MB */
+#define VR_DPDK_MAX_MEM             "512"
+/* Number of memory channels to use */
+#define VR_DPDK_MAX_MEMCHANNELS     "4"
+/* Use UDP source port hashing */
+#define VR_DPDK_USE_MPLS_UDP_ECMP   true
+/* Use hardware filtering (Flow Director) */
+#define VR_DPDK_USE_HW_FILTERING    false
+/* KNI generates random MACs for e1000e NICs, so we need this
+ * option enabled for the development on servers with those NICs */
+#define VR_DPDK_ENABLE_PROMISC      false
+/* Maximum number of hardware RX queues to use for RSS and filtering
+ * (limited by NIC and number of per queue TX/RX descriptors) */
+#define VR_DPDK_MAX_NB_RX_QUEUES    11
+/* Maximum number of hardware TX queues to use (limited by the number of lcores) */
+#define VR_DPDK_MAX_NB_TX_QUEUES    5
+/* Maximum number of hardware RX queues to use for RSS (limited by the number of lcores) */
+#define VR_DPDK_MAX_NB_RSS_QUEUES   4
+/* Number of hardware RX ring descriptors */
+#define VR_DPDK_NB_RXD              256
+/* Number of hardware TX ring descriptors */
+#define VR_DPDK_NB_TXD              512
+/* Offset to MPLS label for hardware filtering (in 16-bit word units) */
+#define VR_DPDK_MPLS_OFFSET         ((VR_ETHER_HLEN             \
+                                    + sizeof(struct vr_ip)      \
+                                    + sizeof(struct vr_udp))/2)
+/* Maximum number of rings per lcore (maximum is VR_MAX_INTERFACES*RTE_MAX_LCORE) */
+#define VR_DPDK_MAX_RINGS           (VR_MAX_INTERFACES*2)
+/* Max size of a single packet */
+#define VR_DPDK_MAX_PACKET_SZ       2048
+/* Number of bytes needed for each mbuf */
+#define VR_DPDK_MBUF_SZ             (VR_DPDK_MAX_PACKET_SZ      \
+                                    + sizeof(struct rte_mbuf)   \
+                                    + RTE_PKTMBUF_HEADROOM      \
+                                    + sizeof(struct vr_packet))
+/* How many packets to read/write from/to queue in one go */
+#define VR_DPDK_MAX_BURST_SZ        RTE_PORT_IN_BURST_SIZE_MAX
+#define VR_DPDK_ETH_RX_BURST_SZ     32
+#define VR_DPDK_ETH_TX_BURST_SZ     32
+#define VR_DPDK_KNI_RX_BURST_SZ     32
+#define VR_DPDK_KNI_TX_BURST_SZ     32
+#define VR_DPDK_RING_RX_BURST_SZ    32
+#define VR_DPDK_RING_TX_BURST_SZ    32
+/* Number of mbufs in TX ring */
+#define VR_DPDK_TX_RING_SZ          (VR_DPDK_MAX_BURST_SZ*2)
+/* Number of mbufs in virtio mempool */
+#define VR_DPDK_VIRTIO_MEMPOOL_SZ   8192
+/* How many objects (mbufs) to keep in per-lcore virtio mempool cache */
+#define VR_DPDK_VIRTIO_MEMPOOL_CACHE_SZ (VR_DPDK_VIRTIO_RX_BURST_SZ*8)
+/* Number of mbufs in RSS mempool */
+#define VR_DPDK_RSS_MEMPOOL_SZ      8192
+/* How many objects (mbufs) to keep in per-lcore RSS mempool cache */
+#define VR_DPDK_RSS_MEMPOOL_CACHE_SZ    (VR_DPDK_MAX_BURST_SZ*8)
+/* Number of VM mempools */
+#define VR_DPDK_MAX_VM_MEMPOOLS     (VR_DPDK_MAX_NB_RX_QUEUES*2 - VR_DPDK_MIN_LCORES)
+/* Number of mbufs in VM mempool */
+#define VR_DPDK_VM_MEMPOOL_SZ       1024
+/* How many objects (mbufs) to keep in per-lcore VM mempool cache */
+#define VR_DPDK_VM_MEMPOOL_CACHE_SZ (VR_DPDK_MAX_BURST_SZ*8)
+/* Use timer to measure flushes (slower, but should improve latency) */
+#define VR_DPDK_USE_TIMER           false
+/* TX flush timeout (in loops or US if USE_TIMER defined) */
+#define VR_DPDK_TX_FLUSH_LOOPS      5
+#define VR_DPDK_TX_FLUSH_US         100
+/* Sleep time in US if there are no queues to poll */
+#define VR_DPDK_SLEEP_NO_QUEUES_US  10000
+/* Sleep (in US) or yield if no packets received (use 0 to disable) */
+#define VR_DPDK_SLEEP_NO_PACKETS_US 0
+#define VR_DPDK_YIELD_NO_PACKETS    1
+/* Timers handling periodicity in US */
+#define VR_DPDK_SLEEP_TIMER_US      100
+/* KNI handling periodicity in US */
+#define VR_DPDK_SLEEP_KNI_US        500
+/* Sleep time in US for service lcore */
+#define VR_DPDK_SLEEP_SERVICE_US    100
+/* Invalid port ID */
+#define VR_DPDK_INVALID_PORT_ID     0xFF
+/* Invalid queue ID */
+#define VR_DPDK_INVALID_QUEUE_ID    0xFFFF
+
+/*
+ * VRouter/DPDK Data Structures
+ * ============================
+ *
+ * Changes since the initial commit:
+ *   lcore_ctx -> vr_dpdk_lcore
+ *   vif_port -> vr_dpdk_queue
+ *
+ * TODO: update the description
+ */
+
+/* Init queue operation */
+typedef struct vr_dpdk_queue *
+    (*vr_dpdk_queue_init_op)(unsigned lcore_id, struct vr_interface *vif,
+        unsigned queue_or_lcore_id);
+/* Release queue operation */
+typedef void
+    (*vr_dpdk_queue_release_op)(unsigned lcore_id, struct vr_interface *vif);
+
+struct vr_dpdk_queue {
+    SLIST_ENTRY(vr_dpdk_queue) q_next;
+    union {
+        /* DPDK TX queue operators */
+        struct rte_port_out_ops txq_ops;
+        /* DPDK RX queue operators */
+        struct rte_port_in_ops rxq_ops;
+    };
+    /* Queue handler */
+    void *q_queue_h;
+    /* Pointer to vRouter interface */
+    struct vr_interface *q_vif;
+    /* RX burst size */
+    uint16_t rxq_burst_size;
+};
+
+/* We store the queue params in the separate structure to increase CPU
+ * cache hit rate
+ */
+struct vr_dpdk_queue_params {
+    /* Pointer to release function */
+    vr_dpdk_queue_release_op qp_release_op;
+    /* Extra queue params */
+    union {
+        struct {
+            struct rte_ring *ring_p;
+            unsigned host_lcore_id;
+        } qp_ring;
+    };
+};
+
+struct vr_dpdk_ring_to_push {
+    /* Ring pointer */
+    struct rte_ring *rtp_tx_ring;
+    /* TX queue pointer */
+    struct vr_dpdk_queue *rtp_tx_queue;
+};
+
+SLIST_HEAD(vr_dpdk_q_slist, vr_dpdk_queue);
+
+/* Lcore commands */
+enum vr_dpdk_lcore_cmd {
+    /* No command */
+    VR_DPDK_LCORE_NO_CMD = 0,
+    /* Stop and exit the lcore loop */
+    VR_DPDK_LCORE_STOP_CMD,
+    /* Remove RX queue */
+    VR_DPDK_LCORE_RX_RM_CMD,
+    /* Remove TX queue */
+    VR_DPDK_LCORE_TX_RM_CMD,
+};
+
+struct vr_dpdk_lcore {
+    /* RX queues head */
+    struct vr_dpdk_q_slist lcore_rx_head;
+    /* Table of RX queues */
+    struct vr_dpdk_queue lcore_rx_queues[VR_MAX_INTERFACES];
+    /* TX queues head */
+    struct vr_dpdk_q_slist lcore_tx_head;
+    /* Table of TX queues */
+    struct vr_dpdk_queue lcore_tx_queues[VR_MAX_INTERFACES];
+    /* Number of rings to push for the lcore */
+    volatile uint16_t lcore_nb_rings_to_push;
+    /* List of rings to push */
+    struct vr_dpdk_ring_to_push lcore_rings_to_push[VR_DPDK_MAX_RINGS];
+    /* Table of RX queue params */
+    struct vr_dpdk_queue_params lcore_rx_queue_params[VR_MAX_INTERFACES];
+    /* Table of TX queue params */
+    struct vr_dpdk_queue_params lcore_tx_queue_params[VR_MAX_INTERFACES];
+    /* Event socket */
+    void *lcore_event_sock;
+    /* Lcore command param */
+    rte_atomic32_t lcore_cmd_param;
+    /* Lcore command */
+    rte_atomic16_t lcore_cmd;
+    /* Number of RX queues assigned to the lcore (for the scheduler) */
+    uint16_t lcore_nb_rx_queues;
+};
+
+/* Hardware RX queue state */
+enum vr_dpdk_queue_state {
+    /* No queue available */
+    VR_DPDK_QUEUE_NONE,
+    /* The queue is ready to use for RSS or filtering */
+    VR_DPDK_QUEUE_READY_STATE,
+    /* The queue is being used for RSS */
+    VR_DPDK_QUEUE_RSS_STATE,
+    /* The queue is being used for filtering */
+    VR_DPDK_QUEUE_FILTERING_STATE
+};
+
+/* Ethdev configuration */
+struct vr_dpdk_ethdev {
+    /* Pointer to ethdev or NULL if the device is not used */
+    struct rte_eth_dev *ethdev_ptr;
+    /* Number of HW RX queues (limited by NIC hardware) */
+    uint16_t ethdev_nb_rx_queues;
+    /* Number of HW TX queues (limited by the nb of lcores) */
+    uint16_t ethdev_nb_tx_queues;
+    /* Number of HW RX queues used for RSS (limited by the nb of lcores) */
+    uint16_t ethdev_nb_rss_queues;
+    uint8_t ethdev_port_id;
+    /* Hardware RX queue states */
+    uint8_t ethdev_queue_states[VR_DPDK_MAX_NB_RX_QUEUES];
+    /* Pointers to memory pools */
+    struct rte_mempool *ethdev_mempools[VR_DPDK_MAX_NB_RX_QUEUES];
+};
+
+struct vr_dpdk_global {
+    /* Pointer to virtio memory pool */
+    struct rte_mempool *virtio_mempool;
+    /* Pointer to RSS memory pool */
+    struct rte_mempool *rss_mempool;
+    /* Number of free memory pools */
+    uint16_t nb_free_mempools;
+    /* List of free memory pools */
+    struct rte_mempool *free_mempools[VR_DPDK_MAX_VM_MEMPOOLS];
+    /* Number of forwarding lcores */
+    unsigned nb_fwd_lcores;
+    /* Table of pointers to forwarding lcore */
+    struct vr_dpdk_lcore *lcores[RTE_MAX_LCORE];
+    /* Global stop flag */
+    rte_atomic16_t stop_flag;
+    /* NetLink socket handler */
+    void *netlink_sock;
+    void *flow_table;
+    /* Packet socket */
+    struct rte_ring *packet_ring;
+    void *packet_transport;
+    unsigned packet_lcore_id;
+    /* KNI thread ID */
+    pthread_t kni_thread;
+    /* Timer thread ID */
+    pthread_t timer_thread;
+    /* User space vhost thread */
+    pthread_t uvh_thread;
+    /* Table of KNIs */
+    struct rte_kni *knis[VR_MAX_INTERFACES];
+    /* Table of vHosts */
+    struct vr_interface *vhosts[VR_MAX_INTERFACES];
+    /* Table of ethdevs */
+    struct vr_dpdk_ethdev ethdevs[RTE_MAX_ETHPORTS];
+    /* Table of monitoring redirections (for tcpdump) */
+    uint16_t monitorings[VR_MAX_INTERFACES];
+    /* Interface configuration mutex
+     * ATM we use it just to synchronize access between the NetLink interface
+     * and kernel KNI events. The datapath is not affected. */
+    pthread_mutex_t if_lock;
+};
+
+extern struct vr_dpdk_global vr_dpdk;
+
+/*
+ * rte_mbuf <=> vr_packet conversion
+ *
+ * We use the tailroom to store vr_packet structure:
+ *     struct rte_mbuf + headroom + data + tailroom + struct vr_packet
+ *
+ * rte_mbuf: *buf_addr(buf_len) + headroom + *pkt.data(data_len) + tailroom
+ *
+ * rte_mbuf->buf_addr = rte_mbuf + sizeof(rte_mbuf)
+ * rte_mbuf->buf_len = elt_size - sizeof(rte_mbuf) - sizeof(vr_packet)
+ * rte_mbuf->pkt.data = rte_mbuf->buf_addr + RTE_PKTMBUF_HEADROOM
+ *
+ *
+ * vr_packet: *vp_head + headroom + vp_data(vp_len) + vp_tail + tailroom
+ *                + vp_end
+ *
+ * vr_packet->vp_head = rte_mbuf->buf_addr (set in mbuf constructor)
+ * vr_packet->vp_data = rte_mbuf->pkt.data - rte_mbuf->buf_addr
+ * vr_packet->vp_len  = rte_mbuf->pkt.data_len
+ * vr_packet->vp_tail = vr_packet->vp_data + vr_packet->vp_len
+ * vr_packet->vp_end  = rte_mbuf->buf_len (set in mbuf constructor)
+ */
+static inline struct rte_mbuf *
+vr_dpdk_pkt_to_mbuf(struct vr_packet *pkt)
+{
+    return (struct rte_mbuf *)((uintptr_t)pkt->vp_head - sizeof(struct rte_mbuf));
+}
+static inline struct vr_packet *
+vr_dpdk_mbuf_to_pkt(struct rte_mbuf *mbuf)
+{
+    return (struct vr_packet *)((uintptr_t)mbuf->buf_addr + mbuf->buf_len);
+}
+
+/*
+ * vr_dpdk_mbuf_reset - if the mbuf changes, possibley due to
+ * pskb_may_pull, reset fields of the pkt structure that point at
+ * the mbuf fields.
+ * Note: we do not reset pkt->data here
+ */
+static inline void
+vr_dpdk_mbuf_reset(struct vr_packet *pkt)
+{
+    struct rte_mbuf *mbuf = vr_dpdk_pkt_to_mbuf(pkt);
+
+    pkt->vp_head = mbuf->buf_addr;
+    pkt->vp_tail = rte_pktmbuf_headroom(mbuf) + mbuf->pkt.data_len;
+    pkt->vp_end = mbuf->buf_len;
+    pkt->vp_len = pkt->vp_tail - pkt->vp_data;
+
+    return;
+}
+
+/*
+ * dpdk_vrouter.c
+ */
+/* pktmbuf constructor with vr_packet support */
+void vr_dpdk_pktmbuf_init(struct rte_mempool *mp, void *opaque_arg, void *_m, unsigned i);
+
+/*
+ * vr_dpdk_ethdev.c
+ */
+/* Init eth RX queue */
+struct vr_dpdk_queue *
+vr_dpdk_ethdev_rx_queue_init(unsigned lcore_id, struct vr_interface *vif,
+    unsigned rx_queue_id);
+/* Init eth TX queue */
+struct vr_dpdk_queue *
+vr_dpdk_ethdev_tx_queue_init(unsigned lcore_id, struct vr_interface *vif,
+    unsigned tx_queue_id);
+/* Init ethernet device */
+int vr_dpdk_ethdev_init(struct vr_dpdk_ethdev *);
+/* Release ethernet device */
+int vr_dpdk_ethdev_release(struct vr_dpdk_ethdev *);
+/* Get free queue ID */
+uint16_t vr_dpdk_ethdev_ready_queue_id_get(struct vr_interface *vif);
+/* Add hardware filter */
+int vr_dpdk_ethdev_filter_add(struct vr_interface *vif, uint16_t queue_id,
+    unsigned dst_ip, unsigned mpls_label);
+/* Init hardware filtering */
+int vr_dpdk_ethdev_filtering_init(struct vr_interface *vif, struct vr_dpdk_ethdev *ethdev);
+/* Init RSS */
+int vr_dpdk_ethdev_rss_init(struct vr_dpdk_ethdev *ethdev);
+
+/*
+ * vr_dpdk_flow_mem.c
+ */
+int vr_dpdk_flow_mem_init(void);
+int vr_dpdk_flow_init(void);
+
+/*
+ * vr_dpdk_host.c
+ */
+int vr_dpdk_host_init(void);
+void vr_dpdk_host_exit(void);
+/* Convert internal packet fields */
+struct vr_packet * vr_dpdk_packet_get(struct rte_mbuf *m, struct vr_interface *vif);
+
+/*
+ * vr_dpdk_interface.c
+ */
+/* Lock interface operations */
+static inline int vr_dpdk_if_lock()
+{ return pthread_mutex_lock(&vr_dpdk.if_lock); }
+/* Unlock interface operations */
+static inline int vr_dpdk_if_unlock()
+{ return pthread_mutex_unlock(&vr_dpdk.if_lock); }
+
+/*
+ * vr_dpdk_knidev.c
+ */
+/* Init KNI */
+int vr_dpdk_knidev_init(struct vr_interface *vif);
+/* Release KNI */
+int vr_dpdk_knidev_release(struct vr_interface *vif);
+/* Init KNI RX queue */
+struct vr_dpdk_queue *
+vr_dpdk_kni_rx_queue_init(unsigned lcore_id, struct vr_interface *vif,
+    unsigned host_lcore_id);
+/* Init KNI TX queue */
+struct vr_dpdk_queue *
+vr_dpdk_kni_tx_queue_init(unsigned lcore_id, struct vr_interface *vif,
+    unsigned host_lcore_id);
+/* Handle all KNIs attached */
+void vr_dpdk_knidev_all_handle(void);
+
+/*
+ * vr_dpdk_packet.c
+ */
+int vr_dpdk_packet_tx(void);
+int dpdk_packet_socket_init(void);
+void dpdk_packet_socket_close(void);
+int dpdk_packet_io(void);
+
+/*
+ * vr_dpdk_lcore.c
+ */
+/* Launch lcore main loop */
+int vr_dpdk_lcore_launch(void *dummy);
+/* Schedule an interface */
+int vr_dpdk_lcore_if_schedule(struct vr_interface *vif, unsigned least_used_id,
+    uint16_t nb_rx_queues, vr_dpdk_queue_init_op rx_queue_init_op,
+    uint16_t nb_tx_queues, vr_dpdk_queue_init_op tx_queue_init_op);
+/* Unschedule an interface */
+void vr_dpdk_lcore_if_unschedule(struct vr_interface *vif);
+/* Schedule an MPLS label queue */
+int vr_dpdk_lcore_mpls_schedule(struct vr_interface *vif, unsigned dst_ip,
+    unsigned mpls_label);
+/* Returns the least used lcore or RTE_MAX_LCORE */
+unsigned vr_dpdk_lcore_least_used_get(void);
+/* Returns the least used lcore among the ones that handle physical intf TX */
+unsigned int vr_dpdk_phys_lcore_least_used_get(void);
+/* Flush TX queues */
+static inline void
+vr_dpdk_lcore_flush(struct vr_dpdk_lcore *lcore)
+{
+    struct vr_dpdk_queue *tx_queue;
+    SLIST_FOREACH(tx_queue, &lcore->lcore_tx_head, q_next) {
+        tx_queue->txq_ops.f_flush(tx_queue->q_queue_h);
+    }
+    vr_dpdk_packet_tx();
+}
+/* Send a burst of vr_packets to vRouter */
+void
+vr_dpdk_packets_vroute(struct vr_interface *vif,
+    struct vr_packet *pkts[VR_DPDK_MAX_BURST_SZ], uint32_t nb_pkts);
+/* Handle an IPC command */
+int
+vr_dpdk_lcore_cmd_handle(struct vr_dpdk_lcore *lcore);
+/* Post an lcore command */
+void
+vr_dpdk_lcore_cmd_post(struct vr_dpdk_lcore *lcore, uint16_t cmd,
+    uint32_t cmd_param);
+
+
+/*
+ * vr_dpdk_netlink.c
+ */
+void dpdk_netlink_exit(void);
+int dpdk_netlink_init(void);
+int dpdk_netlink_receive(void *usockp, char *nl_buf, unsigned int nl_len);
+int dpdk_netlink_io(void);
+
+/*
+ * vr_dpdk_ringdev.c
+ */
+/* Allocates a new ring */
+struct rte_ring *
+vr_dpdk_ring_allocate(unsigned host_lcore_id, char *ring_name,
+    unsigned vr_dpdk_tx_ring_sz);
+/* Init ring RX queue */
+struct vr_dpdk_queue *
+vr_dpdk_ring_rx_queue_init(unsigned lcore_id, struct vr_interface *vif,
+    unsigned host_lcore_id);
+/* Init ring TX queue */
+struct vr_dpdk_queue *
+vr_dpdk_ring_tx_queue_init(unsigned lcore_id, struct vr_interface *vif,
+    unsigned host_lcore_id);
+void dpdk_ring_to_push_add(unsigned lcore_id, struct rte_ring *tx_ring,
+    struct vr_dpdk_queue *tx_queue);
+
+void
+dpdk_ring_to_push_remove(unsigned lcore_id, struct rte_ring *tx_ring);
+
+#endif /*_VR_DPDK_H_ */

--- a/include/vr_dpdk.h
+++ b/include/vr_dpdk.h
@@ -129,6 +129,8 @@
 #define VR_DPDK_INVALID_PORT_ID     0xFF
 /* Invalid queue ID */
 #define VR_DPDK_INVALID_QUEUE_ID    0xFFFF
+/* Socket connection retry timeout in seconds (use power of 2) */
+#define VR_DPDK_RETRY_CONNECT_SECS  64
 
 /*
  * VRouter/DPDK Data Structures
@@ -397,6 +399,9 @@ int vr_dpdk_host_init(void);
 void vr_dpdk_host_exit(void);
 /* Convert internal packet fields */
 struct vr_packet * vr_dpdk_packet_get(struct rte_mbuf *m, struct vr_interface *vif);
+/* Retry socket connection */
+int vr_dpdk_retry_connect(int sockfd, const struct sockaddr *addr,
+                            socklen_t alen);
 
 /*
  * vr_dpdk_interface.c

--- a/include/vr_dpdk.h
+++ b/include/vr_dpdk.h
@@ -360,6 +360,8 @@ vr_dpdk_mbuf_reset(struct vr_packet *pkt)
  */
 /* pktmbuf constructor with vr_packet support */
 void vr_dpdk_pktmbuf_init(struct rte_mempool *mp, void *opaque_arg, void *_m, unsigned i);
+/* Check if the stop flag is set */
+int vr_dpdk_is_stop_flag_set(void);
 
 /*
  * vr_dpdk_ethdev.c

--- a/include/vr_dpdk.h
+++ b/include/vr_dpdk.h
@@ -44,8 +44,8 @@
 #define VR_DPDK_TX_PKT_DUMP
  */
 
-/* lcore mask */
-#define VR_DPDK_LCORE_MASK          0x3f
+/* Default lcore mask. Used only when sched_getaffinity() is failed */
+#define VR_DPDK_DEF_LCORE_MASK      0xf
 /* Number of service lcores */
 #define VR_DPDK_NB_SERVICE_LCORES   2
 /* Minimum number of lcores */

--- a/include/vr_dpdk.h
+++ b/include/vr_dpdk.h
@@ -33,12 +33,14 @@
 
 #define RTE_LOGTYPE_VROUTER         RTE_LOGTYPE_USER1
 #define RTE_LOGTYPE_USOCK           RTE_LOGTYPE_USER2
+#define RTE_LOGTYPE_UVHOST          RTE_LOGTYPE_USER3
 #undef RTE_LOG_LEVEL
 #define RTE_LOG_LEVEL               RTE_LOG_DEBUG
 #define VR_DPDK_RX_PKT_DUMP
 #define VR_DPDK_TX_PKT_DUMP
 #define VR_DPDK_PKT_DUMP_VIF_FILTER(vif) ((vif)->vif_type == VIF_TYPE_AGENT \
-                                            || (vif)->vif_type == VIF_TYPE_VIRTUAL)
+                                        || (vif)->vif_type == VIF_TYPE_VIRTUAL)
+
 /*
  * Debug options:
  *
@@ -48,7 +50,7 @@
 #define VR_DPDK_RX_PKT_DUMP
 #define VR_DPDK_TX_PKT_DUMP
 #define VR_DPDK_PKT_DUMP_VIF_FILTER(vif) (vif->vif_type == VIF_TYPE_AGENT \
-                                            || vif->vif_type == VIF_TYPE_VIRTUAL)
+                                        || vif->vif_type == VIF_TYPE_VIRTUAL)
  */
 
 /* Default lcore mask. Used only when sched_getaffinity() is failed */

--- a/include/vr_dpdk.h
+++ b/include/vr_dpdk.h
@@ -436,7 +436,7 @@ void vr_dpdk_knidev_all_handle(void);
 /*
  * vr_dpdk_packet.c
  */
-void vr_dpdk_packet_tx(struct vr_dpdk_lcore *lcore);
+void vr_dpdk_packet_wakeup(struct vr_dpdk_lcore *lcorep);
 int dpdk_packet_socket_init(void);
 void dpdk_packet_socket_close(void);
 int dpdk_packet_io(void);
@@ -467,7 +467,7 @@ vr_dpdk_lcore_flush(struct vr_dpdk_lcore *lcore)
     SLIST_FOREACH(tx_queue, &lcore->lcore_tx_head, q_next) {
         tx_queue->txq_ops.f_flush(tx_queue->q_queue_h);
     }
-    vr_dpdk_packet_tx(lcore);
+    vr_dpdk_packet_wakeup(lcore);
 }
 /* Send a burst of vr_packets to vRouter */
 void

--- a/include/vr_dpdk.h
+++ b/include/vr_dpdk.h
@@ -434,7 +434,7 @@ void vr_dpdk_knidev_all_handle(void);
 /*
  * vr_dpdk_packet.c
  */
-int vr_dpdk_packet_tx(void);
+void vr_dpdk_packet_tx(struct vr_dpdk_lcore *lcore);
 int dpdk_packet_socket_init(void);
 void dpdk_packet_socket_close(void);
 int dpdk_packet_io(void);
@@ -465,7 +465,7 @@ vr_dpdk_lcore_flush(struct vr_dpdk_lcore *lcore)
     SLIST_FOREACH(tx_queue, &lcore->lcore_tx_head, q_next) {
         tx_queue->txq_ops.f_flush(tx_queue->q_queue_h);
     }
-    vr_dpdk_packet_tx();
+    vr_dpdk_packet_tx(lcore);
 }
 /* Send a burst of vr_packets to vRouter */
 void

--- a/include/vr_dpdk.h
+++ b/include/vr_dpdk.h
@@ -474,7 +474,6 @@ vr_dpdk_lcore_flush(struct vr_dpdk_lcore *lcore)
     SLIST_FOREACH(tx_queue, &lcore->lcore_tx_head, q_next) {
         tx_queue->txq_ops.f_flush(tx_queue->q_queue_h);
     }
-    vr_dpdk_packet_wakeup(lcore);
 }
 /* Send a burst of vr_packets to vRouter */
 void

--- a/include/vr_dpdk.h
+++ b/include/vr_dpdk.h
@@ -32,8 +32,13 @@
 #include <rte_port.h>
 
 #define RTE_LOGTYPE_VROUTER         RTE_LOGTYPE_USER1
+#define RTE_LOGTYPE_USOCK           RTE_LOGTYPE_USER2
 #undef RTE_LOG_LEVEL
-#define RTE_LOG_LEVEL               RTE_LOG_INFO
+#define RTE_LOG_LEVEL               RTE_LOG_DEBUG
+#define VR_DPDK_RX_PKT_DUMP
+#define VR_DPDK_TX_PKT_DUMP
+#define VR_DPDK_PKT_DUMP_VIF_FILTER(vif) ((vif)->vif_type == VIF_TYPE_AGENT \
+                                            || (vif)->vif_type == VIF_TYPE_VIRTUAL)
 /*
  * Debug options:
  *
@@ -42,6 +47,8 @@
 #define VR_DPDK_NETLINK_PKT_DUMP
 #define VR_DPDK_RX_PKT_DUMP
 #define VR_DPDK_TX_PKT_DUMP
+#define VR_DPDK_PKT_DUMP_VIF_FILTER(vif) (vif->vif_type == VIF_TYPE_AGENT \
+                                            || vif->vif_type == VIF_TYPE_VIRTUAL)
  */
 
 /* Default lcore mask. Used only when sched_getaffinity() is failed */

--- a/include/vr_dpdk.h
+++ b/include/vr_dpdk.h
@@ -411,6 +411,26 @@ struct vr_packet * vr_dpdk_packet_get(struct rte_mbuf *m, struct vr_interface *v
 /* Retry socket connection */
 int vr_dpdk_retry_connect(int sockfd, const struct sockaddr *addr,
                             socklen_t alen);
+/* Generates unique log message */
+int vr_dpdk_ulog(uint32_t level, uint32_t logtype, uint32_t *last_hash,
+                    const char *format, ...);
+#define DPDK_ULOG(l, t, h, ...)                         \
+    (void)(((RTE_LOG_ ## l <= RTE_LOG_LEVEL) &&         \
+    (RTE_LOG_ ## l <= rte_logs.level) &&                \
+    (RTE_LOGTYPE_ ## t & rte_logs.type)) ?              \
+    vr_dpdk_ulog(RTE_LOG_ ## l,                         \
+        RTE_LOGTYPE_ ## t, h, # t ": " __VA_ARGS__) : 0)
+
+#if RTE_LOG_LEVEL == RTE_LOG_DEBUG
+#define DPDK_DEBUG_VAR(v) v
+#define DPDK_UDEBUG(t, h, ...)                          \
+    (void)(((RTE_LOGTYPE_ ## t & rte_logs.type)) ?      \
+    vr_dpdk_ulog(RTE_LOG_DEBUG,                         \
+        RTE_LOGTYPE_ ## t, h, # t ": " __VA_ARGS__) : 0)
+#else
+#define DPDK_DEBUG_VAR(v)
+#define DPDK_UDEBUG(t, h, ...)
+#endif
 
 /*
  * vr_dpdk_interface.c

--- a/include/vr_dpdk_usocket.h
+++ b/include/vr_dpdk_usocket.h
@@ -1,0 +1,135 @@
+/*
+ * vr_dpdk_usocket.h -- user space io helpers
+ *
+ * Copyright (c) 2014, Juniper Networks, Inc.
+ * All rights reserved
+ */
+#ifndef __VR_DPDK_USOCKET_H__
+#define __VR_DPDK_USOCKET_H__
+
+#include "vr_queue.h"
+
+/*
+ * usocket is an object where io happens. while it can represent non
+ * socket objects too (like an eventfd), most consumers are socket
+ * users and hence usocket is primarily a socket.
+ *
+ * A socket, when used for io, has to have a protocol to understand
+ * the format of the data that enters and exits it. We have three
+ * protocols: NETLINK, PACKET and EVENT.
+ *
+ * A NETLINK socket carries netlink messages i.e.: each message in the
+ * socket will be headed by a netlink header.
+ *
+ * A PACKET socket carries packets that are headed with agent_hdr. A
+ * PACKET socket is actually a link between the datapath threads and
+ * the agent. The datapath threads enqueue packets that are to be sent
+ * to the agent on a ring and wakeup the packet thread. The packet
+ * thread dequeues the packet from the ring and sends the packet to
+ * the connection with the agent. When a new packet arrives from the
+ * agent, the packet thread wakes up and enqueues it to the vrouter.
+ * So, a PACKET socket has a ring, a vif, and a child usocket that
+ * represents an eventfd that is written by the datapath threads to
+ * wake up the packet thread whenever there are new packets that are
+ * enqueued on the ring.
+ *
+ * The EVENT protocol represent and eventfd. You can write an 8 byte
+ * value that will be accumulated over writes to be read by the reader.
+ *
+ * For each of the protocol, multiple transport types could make sense.
+ * For e.g.: for a NETLINK socket, both a TCP and a UNIX transport could
+ * make sense. However, for a packet socket, only a RAW transport will
+ * make sense.
+ */
+
+/* protocol type */
+#define NETLINK                 1
+#define PACKET                  2
+#define EVENT                   3
+
+/* socket type */
+#define TCP                     1
+#define UNIX                    2
+#define RAW                     3
+
+/* usocket state */
+#define ALLOCED                 0
+#define INITED                  1
+#define LISTENING               2
+#define READING_HEADER          3
+#define READING_DATA            4
+#define READING_FAULTY_DATA     5
+#define LIMITED                 6
+
+#define USOCK_MAX_CHILD_FDS     64
+#define USOCK_RX_BUF_LEN        4096
+#define USOCK_EVENT_BUF_LEN     8
+
+#define PKT0_MBUF_POOL_SIZE     512
+#define PKT0_MBUF_POOL_CACHE_SZ (VR_DPDK_MAX_BURST_SZ*8)
+#define PKT0_MBUF_PACKET_SIZE   2048
+#define PKT0_MAX_IOV_LEN        64
+#define PKT0_MBUF_RING_SIZE     65536
+
+struct vr_usocket {
+    unsigned short usock_type;
+    unsigned short usock_proto;
+    short usock_poll_block;
+    unsigned short usock_io_in_progress;
+    unsigned short usock_should_close;
+
+    int usock_fd;
+    unsigned int usock_state;
+
+    int usock_error;
+    int usock_errno;
+
+    int usock_cfds;
+    int usock_child_index;
+
+    unsigned int usock_max_cfds;
+    unsigned int usock_disconnects;
+
+    struct vr_usocket *usock_parent;
+    struct vr_usocket **usock_children;
+
+    unsigned int usock_read_offset;
+    unsigned int usock_read_len;
+
+    unsigned int usock_buf_len;
+    unsigned int usock_pkt_truncated;
+
+    char *usock_rx_buf;
+
+    struct rte_mbuf *usock_mbuf;
+    struct rte_mempool *usock_mbuf_pool;
+
+    unsigned int usock_write_offset;
+    unsigned int usock_write_len;
+    unsigned char *usock_tx_buf;
+    struct vr_qhead usock_nl_responses;
+
+    struct iovec *usock_iovec;
+
+    struct vr_interface *usock_vif;
+    struct pollfd *usock_pfds;
+};
+
+void *vr_usocket(int, int);
+void vr_usocket_close(void *sock);
+/*
+ * start io on socket
+ */
+int vr_usocket_io(void *transport);
+void vr_usocket_non_blocking(struct vr_usocket *usockp);
+void vr_usocket_attach_vif(void *usockp, struct vr_interface *vif);
+int vr_usocket_bind_usockets(void *usock1, void *usock2);
+int vr_usocket_write(struct vr_usocket *usockp, unsigned char *buf,
+    unsigned int len);
+
+#define VR_NETLINK_TCP_PORT         20914
+#define VR_NETLINK_UNIX_FILE        "/tmp/dpdk_netlink"
+#define VR_PACKET_UNIX_FILE         "/tmp/dpdk_pkt0"
+#define VR_PACKET_AGENT_UNIX_FILE   "/tmp/agent_pkt0"
+
+#endif /* __VR_DPDK_USOCKET_H__ */

--- a/include/vr_dpdk_usocket.h
+++ b/include/vr_dpdk_usocket.h
@@ -128,8 +128,10 @@ int vr_usocket_write(struct vr_usocket *usockp, unsigned char *buf,
     unsigned int len);
 
 #define VR_NETLINK_TCP_PORT         20914
-#define VR_NETLINK_UNIX_FILE        "/tmp/dpdk_netlink"
-#define VR_PACKET_UNIX_FILE         "/tmp/dpdk_pkt0"
-#define VR_PACKET_AGENT_UNIX_FILE   "/tmp/agent_pkt0"
+#define VR_SOCKET_DIR               "/var/run/vrouter"
+#define VR_SOCKET_DIR_MODE          (S_IRWXU | S_IRWXG)
+#define VR_NETLINK_UNIX_FILE        VR_SOCKET_DIR"/dpdk_netlink"
+#define VR_PACKET_UNIX_FILE         VR_SOCKET_DIR"/dpdk_pkt0"
+#define VR_PACKET_AGENT_UNIX_FILE   VR_SOCKET_DIR"/agent_pkt0"
 
 #endif /* __VR_DPDK_USOCKET_H__ */

--- a/include/vr_dpdk_usocket.h
+++ b/include/vr_dpdk_usocket.h
@@ -63,7 +63,7 @@
 
 #define USOCK_MAX_CHILD_FDS     64
 #define USOCK_RX_BUF_LEN        4096
-#define USOCK_EVENT_BUF_LEN     8
+#define USOCK_EVENT_BUF_LEN     sizeof(uint64_t)
 
 #define PKT0_MBUF_POOL_SIZE     512
 #define PKT0_MBUF_POOL_CACHE_SZ (VR_DPDK_MAX_BURST_SZ*8)

--- a/include/vr_dpdk_usocket.h
+++ b/include/vr_dpdk_usocket.h
@@ -129,7 +129,7 @@ int vr_usocket_write(struct vr_usocket *usockp, unsigned char *buf,
 
 #define VR_NETLINK_TCP_PORT         20914
 #define VR_SOCKET_DIR               "/var/run/vrouter"
-#define VR_SOCKET_DIR_MODE          (S_IRWXU | S_IRWXG)
+#define VR_SOCKET_DIR_MODE          (S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
 #define VR_NETLINK_UNIX_FILE        VR_SOCKET_DIR"/dpdk_netlink"
 #define VR_PACKET_UNIX_FILE         VR_SOCKET_DIR"/dpdk_pkt0"
 #define VR_PACKET_AGENT_UNIX_FILE   VR_SOCKET_DIR"/agent_pkt0"

--- a/include/vr_flow.h
+++ b/include/vr_flow.h
@@ -88,7 +88,7 @@ struct vr_flow {
 #define flow4_nh_id     key_u.ip4_key.ip4_nh_id
 #define flow4_proto     key_u.ip4_key.ip4_proto
 
-/* 
+/*
  * Limit the number of outstanding flows in hold state. The flow rate can
  * be much more than what agent can handle. In such cases, to make sure that
  *
@@ -126,7 +126,7 @@ struct vr_flow_table_info {
     uint32_t vfti_hold_count[0];
 };
 
-/* 
+/*
  * flow bytes and packets are of same width. this should be
  * ok since agent really has to take care of overflows. this
  * is also better probably because processor does not have to
@@ -210,6 +210,14 @@ struct vr_flow_entry {
 
 #define VR_DNS_SERVER_PORT  htons(53)
 
+extern unsigned int vr_flow_entries, vr_oflow_entries;
+
+#define VR_FLOW_TABLE_SIZE          (vr_flow_entries * \
+                sizeof(struct vr_flow_entry))
+
+#define VR_OFLOW_TABLE_SIZE         (vr_oflow_entries *\
+                sizeof(struct vr_flow_entry))
+
 struct vr_flow_md {
     struct vrouter *flmd_router;
     struct vr_defer_data *flmd_defer_data;
@@ -232,7 +240,6 @@ extern bool vr_flow_forward(struct vrouter *,
         struct vr_packet *, struct vr_forwarding_md *);
 
 void *vr_flow_get_va(struct vrouter *, uint64_t);
-
 unsigned int vr_flow_table_size(struct vrouter *);
 unsigned int vr_oflow_table_size(struct vrouter *);
 

--- a/include/vr_genetlink.h
+++ b/include/vr_genetlink.h
@@ -1,6 +1,6 @@
 /*
  * vr_genetlink.h -- a place for all the common definitions required by the
- * generic netlink part 
+ * generic netlink part
  *
  * Copyright (c) 2013 Juniper Networks, Inc. All rights reserved.
  */

--- a/include/vr_hash.h
+++ b/include/vr_hash.h
@@ -38,30 +38,30 @@
 #define rolword(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
 
 /* __vr_hash_mix -- mix 3 32-bit values reversibly. */
-#define __vr_hash_mix(a, b, c)			\
-{						\
-	a -= c;  a ^= rolword(c, 4);  c += b;	\
-	b -= a;  b ^= rolword(a, 6);  a += c;	\
-	c -= b;  c ^= rolword(b, 8);  b += a;	\
-	a -= c;  a ^= rolword(c, 16); c += b;	\
-	b -= a;  b ^= rolword(a, 19); a += c;	\
-	c -= b;  c ^= rolword(b, 4);  b += a;	\
+#define __vr_hash_mix(a, b, c)              \
+{                                           \
+    a -= c;  a ^= rolword(c, 4);  c += b;   \
+    b -= a;  b ^= rolword(a, 6);  a += c;   \
+    c -= b;  c ^= rolword(b, 8);  b += a;   \
+    a -= c;  a ^= rolword(c, 16); c += b;   \
+    b -= a;  b ^= rolword(a, 19); a += c;   \
+    c -= b;  c ^= rolword(b, 4);  b += a;   \
 }
 
 /* __vr_hash_final - final mixing of 3 32-bit values (a,b,c) into c */
-#define __vr_hash_final(a, b, c)			\
-{						\
-	c ^= b; c -= rolword(b, 14);		\
-	a ^= c; a -= rolword(c, 11);		\
-	b ^= a; b -= rolword(a, 25);		\
-	c ^= b; c -= rolword(b, 16);		\
-	a ^= c; a -= rolword(c, 4);		\
-	b ^= a; b -= rolword(a, 14);		\
-	c ^= b; c -= rolword(b, 24);		\
+#define __vr_hash_final(a, b, c)            \
+{                                           \
+    c ^= b; c -= rolword(b, 14);            \
+    a ^= c; a -= rolword(c, 11);            \
+    b ^= a; b -= rolword(a, 25);            \
+    c ^= b; c -= rolword(b, 16);            \
+    a ^= c; a -= rolword(c, 4);             \
+    b ^= a; b -= rolword(a, 14);            \
+    c ^= b; c -= rolword(b, 24);            \
 }
 
 /* An arbitrary initial parameter */
-#define VR_HASH_INITVAL		0xdeadbeef
+#define VR_HASH_INITVAL     0xdeadbeef
 
 struct __unaligned_u32 { uint32_t x; } __attribute__((packed));
 static inline uint32_t __get_unaligned_word(const void *p)
@@ -91,42 +91,42 @@ static inline uint32_t __get_unaligned_word(const void *p)
  */
 static inline uint32_t vr_hash(const void *key, uint32_t length, uint32_t initval)
 {
-	uint32_t a, b, c;
-	const uint8_t *k = key;
+    uint32_t a, b, c;
+    const uint8_t *k = key;
 
-	/* Set up the internal state */
-	a = b = c = VR_HASH_INITVAL + length + initval;
+    /* Set up the internal state */
+    a = b = c = VR_HASH_INITVAL + length + initval;
 
-	/* All but the last block: affect some 32 bits of (a,b,c) */
-	while (length > 12) {
-		a += __get_unaligned_word(k);
-		b += __get_unaligned_word(k + 4);
-		c += __get_unaligned_word(k + 8);
-		__vr_hash_mix(a, b, c);
-		length -= 12;
-		k += 12;
-	}
-	/* Last block: affect all 32 bits of (c) */
-	/* All the case statements fall through */
-	switch (length) {
-	case 12: c += (uint32_t)k[11]<<24;
-	case 11: c += (uint32_t)k[10]<<16;
-	case 10: c += (uint32_t)k[9]<<8;
-	case 9:  c += k[8];
-	case 8:  b += (uint32_t)k[7]<<24;
-	case 7:  b += (uint32_t)k[6]<<16;
-	case 6:  b += (uint32_t)k[5]<<8;
-	case 5:  b += k[4];
-	case 4:  a += (uint32_t)k[3]<<24;
-	case 3:  a += (uint32_t)k[2]<<16;
-	case 2:  a += (uint32_t)k[1]<<8;
-	case 1:  a += k[0];
-		 __vr_hash_final(a, b, c);
-	case 0: /* Nothing left to add */
-		break;
-	}
+    /* All but the last block: affect some 32 bits of (a,b,c) */
+    while (length > 12) {
+        a += __get_unaligned_word(k);
+        b += __get_unaligned_word(k + 4);
+        c += __get_unaligned_word(k + 8);
+        __vr_hash_mix(a, b, c);
+        length -= 12;
+        k += 12;
+    }
+    /* Last block: affect all 32 bits of (c) */
+    /* All the case statements fall through */
+    switch (length) {
+    case 12: c += (uint32_t)k[11]<<24;
+    case 11: c += (uint32_t)k[10]<<16;
+    case 10: c += (uint32_t)k[9]<<8;
+    case 9:  c += k[8];
+    case 8:  b += (uint32_t)k[7]<<24;
+    case 7:  b += (uint32_t)k[6]<<16;
+    case 6:  b += (uint32_t)k[5]<<8;
+    case 5:  b += k[4];
+    case 4:  a += (uint32_t)k[3]<<24;
+    case 3:  a += (uint32_t)k[2]<<16;
+    case 2:  a += (uint32_t)k[1]<<8;
+    case 1:  a += k[0];
+         __vr_hash_final(a, b, c);
+    case 0: /* Nothing left to add */
+        break;
+    }
 
-	return c;
+    return c;
 }
 
 /* vr_hash2 - hash an array of u32's
@@ -138,55 +138,55 @@ static inline uint32_t vr_hash(const void *key, uint32_t length, uint32_t initva
  */
 static inline uint32_t vr_hash2(const uint32_t *k, uint32_t length, uint32_t initval)
 {
-	uint32_t a, b, c;
+    uint32_t a, b, c;
 
-	/* Set up the internal state */
-	a = b = c = VR_HASH_INITVAL + (length<<2) + initval;
+    /* Set up the internal state */
+    a = b = c = VR_HASH_INITVAL + (length<<2) + initval;
 
-	/* Handle most of the key */
-	while (length > 3) {
-		a += k[0];
-		b += k[1];
-		c += k[2];
-		__vr_hash_mix(a, b, c);
-		length -= 3;
-		k += 3;
-	}
+    /* Handle most of the key */
+    while (length > 3) {
+        a += k[0];
+        b += k[1];
+        c += k[2];
+        __vr_hash_mix(a, b, c);
+        length -= 3;
+        k += 3;
+    }
 
-	/* Handle the last 3 u32's: all the case statements fall through */
-	switch (length) {
-	case 3: c += k[2];
-	case 2: b += k[1];
-	case 1: a += k[0];
-		__vr_hash_final(a, b, c);
-	case 0:	/* Nothing left to add */
-		break;
-	}
+    /* Handle the last 3 u32's: all the case statements fall through */
+    switch (length) {
+    case 3: c += k[2];
+    case 2: b += k[1];
+    case 1: a += k[0];
+        __vr_hash_final(a, b, c);
+    case 0:    /* Nothing left to add */
+        break;
+    }
 
-	return c;
+    return c;
 }
 
 
 /* vr_hash_3words - hash exactly 3, 2 or 1 word(s) */
 static inline uint32_t vr_hash_3words(uint32_t a, uint32_t b, uint32_t c, uint32_t initval)
 {
-	a += VR_HASH_INITVAL;
-	b += VR_HASH_INITVAL;
-	c += initval;
+    a += VR_HASH_INITVAL;
+    b += VR_HASH_INITVAL;
+    c += initval;
 
-	__vr_hash_final(a, b, c);
+    __vr_hash_final(a, b, c);
 
-	return c;
+    return c;
 }
 
 static inline uint32_t vr_hash_2words(uint32_t a, uint32_t b, uint32_t initval)
 {
-	return vr_hash_3words(a, b, 0, initval);
+    return vr_hash_3words(a, b, 0, initval);
 }
 
 static inline uint32_t vr_hash_1word(uint32_t a, uint32_t initval)
 {
-	return vr_hash_3words(a, 0, 0, initval);
+    return vr_hash_3words(a, 0, 0, initval);
 }
 
 #endif /* _VR_HASH_H */

--- a/include/vr_index_table.h
+++ b/include/vr_index_table.h
@@ -12,7 +12,7 @@ typedef void (*vr_itable_del_cb_t)(unsigned int index, void *data);
 
 vr_itable_t vr_itable_create(unsigned int index_len, unsigned int stride_cnt, ...);
 void vr_itable_delete(vr_itable_t t, vr_itable_del_cb_t func);
-    
+
 void *vr_itable_get(vr_itable_t t, unsigned int index);
 void *vr_itable_del(vr_itable_t t, unsigned int index);
 void *vr_itable_set(vr_itable_t t, unsigned int index, void *data);

--- a/include/vr_linux.h
+++ b/include/vr_linux.h
@@ -6,8 +6,8 @@
 
 #include "vrouter.h"
 
-static inline struct sk_buff * 
-vp_os_packet(struct vr_packet *pkt) 
+static inline struct sk_buff *
+vp_os_packet(struct vr_packet *pkt)
 {
     return CONTAINER_OF(cb, struct sk_buff, pkt);
 }

--- a/include/vr_mirror.h
+++ b/include/vr_mirror.h
@@ -38,7 +38,7 @@ extern int vr_mirror(struct vrouter *, uint8_t, struct vr_packet *,
 extern struct vr_mirror_entry *vrouter_get_mirror(unsigned int, unsigned int);
 extern int vrouter_put_mirror(struct vrouter *, unsigned int);
 extern int vr_mirror_meta_entry_set(struct vrouter *, unsigned int,
-        unsigned int, unsigned short, 
+        unsigned int, unsigned short,
         void *, unsigned int,
         unsigned short);
 extern void vr_mirror_meta_entry_del(struct vrouter *, unsigned int);

--- a/include/vr_mpls.h
+++ b/include/vr_mpls.h
@@ -36,7 +36,7 @@ extern int vr_mpls_input(struct vrouter *, struct vr_packet *,
 
 
 
-static inline bool 
+static inline bool
 vr_mpls_is_label_mcast(unsigned int lbl)
 {
     if (lbl < VR_MAX_UCAST_LABELS) {

--- a/include/vr_os.h
+++ b/include/vr_os.h
@@ -35,7 +35,6 @@
 #include <net/netlink.h>
 #include <net/genetlink.h>
 
-#define vr_printf(format, arg...)   printk(format, ##arg)
 #define ASSERT(x) BUG_ON(!(x));
 
 #else /* __KERNEL */
@@ -49,7 +48,6 @@
 #include <assert.h>
 #include <sys/types.h>
 
-#define vr_printf(format, arg...)   printf(format, ##arg)
 #define ASSERT(x) assert((x));
 
 typedef __signed__ char __s8;

--- a/include/vr_packet.h
+++ b/include/vr_packet.h
@@ -22,10 +22,10 @@
 #define VR_IP_PROTO_IGMP        2
 #define VR_IP_PROTO_TCP         6
 #define VR_IP_PROTO_UDP         17
-#define	VR_IP_PROTO_GRE         47
+#define VR_IP_PROTO_GRE         47
 #define VR_IP_PROTO_ICMP6       58
 #define VR_GRE_FLAG_CSUM        (ntohs(0x8000))
-#define VR_GRE_FLAG_KEY         (ntohs(0x2000)) 
+#define VR_GRE_FLAG_KEY         (ntohs(0x2000))
 #define VR_DHCP_SRC_PORT        68
 #define VR_DHCP6_SRC_PORT       546
 
@@ -73,7 +73,7 @@
 /* Diagnostic packet */
 #define VP_FLAG_DIAG            (1 << 8)
 
-/* 
+/*
  * possible 256 values of what a packet can be. currently, this value is
  * used only as an aid in fragmentation.
  */
@@ -121,8 +121,8 @@
 /*
  * Values to define the encap type of outgoing packet
  */
-#define PKT_ENCAP_MPLS  0x01
-#define PKT_ENCAP_VXLAN 0x02
+#define PKT_ENCAP_MPLS          0x01
+#define PKT_ENCAP_VXLAN         0x02
 
 
 /* packet drop reasons */
@@ -625,7 +625,7 @@ vr_icmp_error(struct vr_icmp *icmph)
 struct vr_gre {
     unsigned short gre_flags;
     unsigned short gre_proto;
-}  __attribute__((packed));
+} __attribute__((packed));
 
 struct vr_pcap {
     /* timestamp seconds */
@@ -633,7 +633,7 @@ struct vr_pcap {
     /* timestamp microseconds */
     unsigned int pcap_ts_usec;
     /* number of octets of packet saved in file */
-    unsigned int pcap_incl_len;         
+    unsigned int pcap_incl_len;
     /* actual length of packet */
     unsigned int pcap_orig_len;
 };
@@ -781,7 +781,7 @@ pkt_get_inner_network_header_off(struct vr_packet *pkt)
 
 }
 
-static inline void 
+static inline void
 pkt_set_network_header(struct vr_packet *pkt, unsigned short off)
 {
     pkt->vp_network_h = off;
@@ -801,7 +801,6 @@ pkt_network_header(struct vr_packet *pkt)
         return pkt->vp_head + pkt->vp_network_h;
 
     return vr_network_header(pkt);
-    
 }
 
 static inline unsigned char *

--- a/include/vr_queue.h
+++ b/include/vr_queue.h
@@ -1,5 +1,5 @@
 /*
- * vr_queue.h -- 
+ * vr_queue.h --
  *
  * Copyright (c) 2013 Juniper Networks, Inc. All rights reserved.
  */

--- a/include/vr_utils.h
+++ b/include/vr_utils.h
@@ -21,8 +21,8 @@ struct vn_if {
 
 struct vr_util_flags {
     unsigned int vuf_flag;
-    unsigned char *vuf_flag_symbol;
-    unsigned char *vuf_flag_string;
+    char *vuf_flag_symbol;
+    char *vuf_flag_string;
 };
 
 #ifdef __cplusplus

--- a/include/vr_vxlan.h
+++ b/include/vr_vxlan.h
@@ -14,7 +14,7 @@ struct vr_packet;
 
 extern int vr_vxlan_init(struct vrouter *);
 extern void vr_vxlan_exit(struct vrouter *, bool);
-extern int vr_vxlan_input(struct vrouter *, struct vr_packet *, 
+extern int vr_vxlan_input(struct vrouter *, struct vr_packet *,
                                     struct vr_forwarding_md *);
 
 

--- a/include/vrouter.h
+++ b/include/vrouter.h
@@ -21,6 +21,7 @@ extern "C" {
 #include "vr_index_table.h"
 
 #define VR_NATIVE_VRF       0
+#define VR_UNIX_PATH_MAX    108
 
 #define VR_CPU_MASK     0xff
 extern unsigned int vr_num_cpus;
@@ -55,6 +56,7 @@ struct vr_timer {
 };
 
 struct host_os {
+    int (*hos_printf)(const char *, ...);
     void *(*hos_malloc)(unsigned int);
     void *(*hos_zalloc)(unsigned int);
     void (*hos_free)(void *);
@@ -95,7 +97,7 @@ struct host_os {
                                    unsigned short, unsigned short *,
                                    int (*is_label_l2)(unsigned int,
                                        unsigned int, unsigned short *));
-    int  (*hos_pcow)(struct vr_packet *, unsigned short); 
+    int  (*hos_pcow)(struct vr_packet *, unsigned short);
     uint16_t (*hos_get_udp_src_port)(struct vr_packet *,
                                      struct vr_forwarding_md *,
                                      unsigned short);
@@ -103,12 +105,15 @@ struct host_os {
     int  (*hos_pull_inner_headers_fast)(struct vr_packet *,
                                         unsigned char, int
                                         (*is_label_l2)(unsigned int,
-                                            unsigned int, unsigned short *), 
+                                            unsigned int, unsigned short *),
                                         int *, int *);
     int (*hos_pkt_may_pull)(struct vr_packet *, unsigned int);
     int (*hos_gro_process)(struct vr_packet *, struct vr_interface *, bool);
+    void (*hos_add_mpls)(struct vrouter *, unsigned);
+    void (*hos_del_mpls)(struct vrouter *, unsigned);
 };
 
+#define vr_printf                       vrouter_host->hos_printf
 #define vr_malloc                       vrouter_host->hos_malloc
 #define vr_zalloc                       vrouter_host->hos_zalloc
 #define vr_free                         vrouter_host->hos_free

--- a/linux/vhost_dev.c
+++ b/linux/vhost_dev.c
@@ -240,7 +240,7 @@ vhost_if_add(struct vr_interface *vif)
             vp->vp_phys_dev =
                 (struct net_device *)vif->vif_bridge->vif_os;
             strncpy(vp->vp_phys_name, vp->vp_phys_dev->name,
-                    sizeof(vp->vp_phys_name));
+                    sizeof(vp->vp_phys_name) - 1);
 
             if (vp->vp_phys_dev->type != ARPHRD_ETHER) {
                 dev->flags |= IFF_NOARP;

--- a/linux/vrouter_mod.c
+++ b/linux/vrouter_mod.c
@@ -33,9 +33,6 @@
 
 unsigned int vr_num_cpus = 1;
 
-extern int vr_flow_entries;
-extern int vr_oflow_entries;
-
 extern unsigned int vr_bridge_entries;
 extern unsigned int vr_bridge_oentries;
 
@@ -72,6 +69,19 @@ extern void vhost_exit(void);
 extern int lh_gro_process(struct vr_packet *, struct vr_interface *, bool);
 
 static void lh_reset_skb_fields(struct vr_packet *pkt);
+
+static int
+lh_printk(const char *format, ...)
+{
+    int printed;
+    va_list args;
+
+    va_start(args, format);
+    printed = vprintk(format, args);
+    va_end(args);
+
+    return printed;
+}
 
 static void *
 lh_malloc(unsigned int size)
@@ -2173,7 +2183,7 @@ lh_pull_inner_headers(struct vr_packet *pkt,
                  }
              } else {
                  if (!ip6h && !vr_ip_fragment(iph)) {
-                     if (iph->ip_proto == VR_IP_PROTO_TCP)  {
+                     if (iph->ip_proto == VR_IP_PROTO_TCP) {
                          lh_handle_checksum_complete_skb(skb);
                          tcpoff = (char *)tcph - (char *) skb->data;
 
@@ -2316,6 +2326,7 @@ lh_create_timer(struct vr_timer *vtimer)
 }
 
 struct host_os linux_host = {
+    .hos_printf                     =       lh_printk,
     .hos_malloc                     =       lh_malloc,
     .hos_zalloc                     =       lh_zalloc,
     .hos_free                       =       lh_free,

--- a/sandesh/vr.sandesh
+++ b/sandesh/vr.sandesh
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2013 Juniper Networks, Inc. All rights reserved.
  */
-	
+
 enum sandesh_op {
     ADD,
     GET,
@@ -75,9 +75,10 @@ buffer sandesh vr_interface_req {
    25: i32          vifr_parent_vif_idx;
    26: i16          vifr_nh_id;
    27: i32          vifr_cross_connect_idx;
-   28:  list<byte>  vifr_src_mac;
+   28: list<byte>   vifr_src_mac;
    29: i32          vifr_bridge_idx;
    30: i16          vifr_ovlan_id;
+   31: byte         vifr_transport;
 }
 
 buffer sandesh vr_vxlan_req {
@@ -148,6 +149,7 @@ buffer sandesh vr_flow_req {
    23: i32          fr_src_nh_index;
    24: i16          fr_flow_nh_id;
    25: i16          fr_drop_reason;
+   26: string       fr_file_path;
 }
 
 buffer sandesh vr_vrf_assign_req {

--- a/test/common_test.c
+++ b/test/common_test.c
@@ -6,7 +6,7 @@ get_random_bytes(void *buf, int nbytes)
 }
 
 uint32_t
-jhash(void *key, uint32_t length, uint32_t interval)
+jhash(void *key, uint32_t length, uint32_t initval)
 {
     uint32_t ret;
     int i;

--- a/test/common_test.h
+++ b/test/common_test.h
@@ -4,6 +4,6 @@
 #include "vr_types.h"
 
 void get_random_bytes(void *buf, int nbytes);
-uint32_t jhash(void *key, uint32_t length, uint32_t interval);
+uint32_t jhash(void *key, uint32_t length, uint32_t initval);
 
 #endif /* __COMMON_TEST_H__ */

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -18,7 +18,7 @@ BIN_FLAGS += -L .
 BIN_FLAGS += -lsandesh-c -lvrutil
 
 LIB_NAME = libvrutil.a
-LIBOBJS = nl_util.lo 
+LIBOBJS = nl_util.lo
 
 VIF = vif
 NH = nh

--- a/utils/SConscript
+++ b/utils/SConscript
@@ -5,7 +5,7 @@
 Import('VRouterEnv')
 env = VRouterEnv.Clone()
 VRutilsEnv = env;
- 
+
 vr_root = '../'
 
 system_header_path = GetOption('system-header-path')
@@ -26,7 +26,8 @@ for sdir in  subdirs:
 
 # Build libvrutil
 libvrutil = 'vrutil'
-libvrutil_objs = [env.Object('nl_util.lo', 'nl_util.c'), env.Object('udp_util.lo', 'udp_util.c')]
+libvrutil_objs = [env.Object('nl_util.lo', 'nl_util.c'), env.Object('udp_util.lo', 'udp_util.c'),
+                  env.Object('ini_parser.lo', 'ini_parser.c')]
 env.StaticLibrary(libvrutil, libvrutil_objs)
 
 env.Replace(LIBPATH = env['TOP_LIB'])
@@ -63,8 +64,9 @@ vxlan = env.Program(target = 'vxlan', source = vxlan_sources)
 
 # to make sure that all are built when you do 'scons' @ the top level
 binaries  = [vif, rt, nh, mirror, mpls, flow, vrfstats, dropstats, vxlan]
+scripts  = ['vifdump']
 env.Default(binaries)
-env.Alias('install', env.Install(env['INSTALL_BIN'], binaries))
+env.Alias('install', env.Install(env['INSTALL_BIN'], binaries + scripts))
 # Local Variables:
 # mode: python
 # End:

--- a/utils/dropstats.c
+++ b/utils/dropstats.c
@@ -35,6 +35,7 @@
 #include "vr_genetlink.h"
 #include "nl_util.h"
 #include "vr_os.h"
+#include "ini_parser.h"
 
 static struct nl_client *cl;
 static int resp_code;
@@ -160,7 +161,7 @@ vr_response_process(void *s)
     if (stats_resp->resp_code < 0) {
         printf("Error %s in kernel operation\n", strerror(stats_resp->resp_code));
         exit(-1);
-    } 
+    }
 
     return;
 }
@@ -191,7 +192,7 @@ vr_build_netlink_request(vr_drop_stats_req *req)
         return ret;
 
     attr_len = nl_get_attr_hdr_size();
-    ret = sandesh_encode(req, "vr_drop_stats_req", vr_find_sandesh_info, 
+    ret = sandesh_encode(req, "vr_drop_stats_req", vr_find_sandesh_info,
                              (nl_get_buf_ptr(cl) + attr_len),
                              (nl_get_buf_len(cl) - attr_len), &error);
 
@@ -215,7 +216,7 @@ vr_send_one_message(void)
     if (ret <= 0)
         return 0;
 
-    while ((ret = nl_recvmsg(cl)) > 0) {
+    if((ret = nl_recvmsg(cl)) > 0) {
         resp = nl_parse_reply(cl);
         if (resp->nl_op == SANDESH_REQUEST)
             sandesh_decode(resp->nl_data, resp->nl_len, vr_find_sandesh_info, &ret);
@@ -231,7 +232,7 @@ vr_drop_stats_op(void)
     return;
 }
 
-static int 
+static int
 vr_get_drop_stats(void)
 {
     int ret;
@@ -289,8 +290,15 @@ main(int argc, char *argv[])
         exit(1);
     }
 
-    ret = nl_socket(cl, NETLINK_GENERIC);    
+    parse_ini_file();
+
+    ret = nl_socket(cl, get_domain(), get_type(), get_protocol());
     if (ret <= 0) {
+       exit(1);
+    }
+
+    ret = nl_connect(cl, get_ip(), get_port());
+    if (ret < 0) {
        exit(1);
     }
 

--- a/utils/flow.c
+++ b/utils/flow.c
@@ -41,10 +41,13 @@
 #include "vr_genetlink.h"
 #include "nl_util.h"
 #include "vr_os.h"
+#include "ini_parser.h"
 #include "vr_packet.h"
 
 #define TABLE_FLAG_VALID        0x1
+
 #define MEM_DEV                 "/dev/flow"
+int mem_fd;
 
 static int dvrf_set, mir_set, help_set;
 static unsigned short dvrf;
@@ -58,9 +61,9 @@ struct flow_table {
     u_int64_t ft_span;
     unsigned int ft_num_entries;
     unsigned int ft_flags;
+    char flow_table_path[256];
 } main_table;
 
-int mem_fd;
 struct nl_client *cl;
 vr_flow_req flow_req;
 
@@ -346,14 +349,20 @@ flow_stats(void)
             }
         }
 
-        system("clear");
+        /* On Ubuntu system() is declared with warn_unused_result
+         * attribute, so we suppress the warning
+         */
+        if (system("clear") == -1) {
+            printf("Error: system() failed\n");
+        }
+
         struct tm *tm;
         char fmt[64], buf[64];
         if((tm = localtime(&now.tv_sec)) != NULL)
         {
             strftime(fmt, sizeof fmt, "%Y-%m-%d %H:%M:%S %z", tm);
             snprintf(buf, sizeof buf, fmt, now.tv_usec);
-            printf("%s\n", buf); 
+            printf("%s\n", buf);
         }
 
         printf("Flow Statistics\n");
@@ -450,18 +459,26 @@ flow_table_map(vr_flow_req *req)
 {
     int ret;
     struct flow_table *ft = &main_table;
+    const char *flow_path;
 
     if (req->fr_ftable_dev < 0)
         exit(ENODEV);
 
-    ret = mknod(MEM_DEV, S_IFCHR | O_RDWR,
-            makedev(req->fr_ftable_dev, req->fr_rid));
-    if (ret && errno != EEXIST) {
-        perror(MEM_DEV);
-        exit(errno);
+    const char *platform = read_string(DEFAULT_SECTION, PLATFORM_KEY);
+    if (platform && ((strcmp(platform, PLATFORM_DPDK) == 0) ||
+                (strcmp(platform, PLATFORM_NIC) == 0))) {
+        flow_path = req->fr_file_path;
+    } else {
+        flow_path = MEM_DEV;
+        ret = mknod(MEM_DEV, S_IFCHR | O_RDWR,
+                makedev(req->fr_ftable_dev, req->fr_rid));
+        if (ret && errno != EEXIST) {
+            perror(MEM_DEV);
+            exit(errno);
+        }
     }
 
-    mem_fd = open(MEM_DEV, O_RDONLY | O_SYNC);
+    mem_fd = open(flow_path, O_RDONLY | O_SYNC);
     if (mem_fd <= 0) {
         perror(MEM_DEV);
         exit(errno);
@@ -531,7 +548,7 @@ make_flow_req(vr_flow_req *req)
     if (ret <= 0)
         return ret;
 
-    while ((ret = nl_recvmsg(cl)) > 0) {
+    if ((ret = nl_recvmsg(cl)) > 0) {
         resp = nl_parse_reply(cl);
         if (resp->nl_op == SANDESH_REQUEST) {
             sandesh_decode(resp->nl_data, resp->nl_len, vr_find_sandesh_info, &ret);
@@ -563,8 +580,13 @@ flow_table_setup(void)
     if (!cl)
         return -ENOMEM;
 
-    ret = nl_socket(cl, NETLINK_GENERIC);
+    parse_ini_file();
+    ret = nl_socket(cl, get_domain(), get_type(), get_protocol());
     if (ret <= 0)
+        return ret;
+
+    ret = nl_connect(cl, get_ip(), get_port());
+    if (ret < 0)
         return ret;
 
     ret = vrouter_get_family_id(cl);

--- a/utils/ini_parser.c
+++ b/utils/ini_parser.c
@@ -122,6 +122,7 @@ read_value(const char *section, const char *key)
     }
 
     bzero(value, sizeof(value));
+    buffer[sizeof(buffer) - 1] = '\0';
     strncpy(buffer, key_start, sizeof(buffer) - 1);
     value_start = strtok(buffer, "=");
     value_start = strtok(NULL, "=");

--- a/utils/ini_parser.c
+++ b/utils/ini_parser.c
@@ -1,0 +1,240 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <malloc.h>
+#include <stdbool.h>
+#include <arpa/inet.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <asm/types.h>
+#include <linux/netlink.h>
+#include <ctype.h>
+#include <stdlib.h>
+
+#include "ini_parser.h"
+
+#define BUF_LENGTH 256
+
+static char value[BUF_LENGTH];
+static char *ini_data = NULL;
+static char ini_file[] = "/etc/contrail/contrail-vrouter-agent.conf";
+
+static void
+copy_line(char *buffer, const char *line, uint32_t *index)
+{
+    uint32_t i = 0;
+    if (line[0] == '#') {
+        return;
+    }
+
+    while(line[i]) {
+        if (isspace(line[i])) {
+            i++;
+            continue;
+        }
+        buffer[(*index)++] = line[i++];
+    }
+    buffer[(*index)++] = '\n';
+}
+
+static int
+read_file_size(const char *file_path)
+{
+    struct stat stat_buffer;
+
+    if (stat(file_path, &stat_buffer) == 0) {
+        return stat_buffer.st_size;
+    }
+    return 0;
+}
+
+int
+parse_ini_file(void)
+{
+    FILE     *fp;
+    char      line[4 * BUF_LENGTH];
+    size_t    size;
+    uint32_t  index = 0;
+
+    fp = fopen(ini_file, "r");
+    if (fp == NULL) {
+        return -1;
+    }
+
+    size = read_file_size(ini_file);
+    /*
+     * Allocate memory to hold read buffer
+     */
+    ini_data = calloc(size, sizeof(char));
+    if (ini_data == NULL) {
+        return -1;
+    }
+
+    while (fgets(line, sizeof(line), fp) != NULL) {
+        copy_line(ini_data, line, &index);
+    }
+
+    fclose(fp);
+    return 0;
+}
+
+bool
+read_value(const char *section, const char *key)
+{
+    const char *section_start = NULL;
+    const char *section_end = NULL;
+    const char *key_start = NULL;
+    const char *value_start = NULL;
+    char section_buffer[BUF_LENGTH];
+    char buffer[BUF_LENGTH];
+
+    if (!ini_data || !section || !key) {
+        return false;
+    }
+
+    snprintf(section_buffer, sizeof(section_buffer), "[%s]", section);
+    /*
+     * Check if section is present
+     */
+    section_start = strstr(ini_data, section_buffer);
+
+    /*
+     * Section is missing
+     */
+    if (section_start == NULL) {
+        return false;
+    }
+
+    section_start += strlen(section_buffer) + 1;
+    section_end = strstr(section_start, "[");
+
+    key_start = strstr(section_start, key);
+    if (key_start == NULL) {
+        return false;
+    }
+
+    if (section_end && key_start > section_end) {
+        //Key not found in same section
+        return false;
+    }
+
+    bzero(value, sizeof(value));
+    strncpy(buffer, key_start, sizeof(buffer) - 1);
+    value_start = strtok(buffer, "=");
+    value_start = strtok(NULL, "=");
+    if (value_start) {
+        strcpy(value, value_start);
+        char *newline = strchr(value,'\n');
+        *newline = '\0';
+        return true;
+    }
+    return false;
+}
+
+int
+read_int(const char *section, const char *key)
+{
+    if (read_value(section, key) == false) {
+        return 0;
+    }
+    return atoi(value);
+}
+
+const char*
+read_string(const char *section, const char *key)
+{
+    if (read_value(section, key) == false) {
+        return NULL;
+    }
+    return value;
+}
+
+uint32_t
+read_ip(const char *section, const char *key)
+{
+    struct in_addr ip;
+
+    if (read_value(section, key) == false) {
+        return 0;
+    }
+
+    if (inet_pton(AF_INET, value, &ip) == 1) {
+        return ntohl(ip.s_addr);
+    }
+    return 0;
+}
+
+int
+get_domain()
+{
+    const char *platform = read_string(DEFAULT_SECTION, PLATFORM_KEY);
+    if (platform &&
+       (strcmp(platform, PLATFORM_DPDK) == 0 ||
+        strcmp(platform, PLATFORM_NIC) == 0)) {
+        return AF_INET;
+    }
+    return AF_NETLINK;
+}
+
+int
+get_type()
+{
+    const char *platform = read_string(DEFAULT_SECTION, PLATFORM_KEY);
+    if (platform &&
+        (strcmp(platform, PLATFORM_DPDK) == 0 ||
+         strcmp(platform, PLATFORM_NIC) == 0)) {
+        return SOCK_STREAM;
+    }
+    return SOCK_DGRAM;
+}
+
+uint16_t
+get_port()
+{
+    const char *platform = read_string(DEFAULT_SECTION, PLATFORM_KEY);
+    if (platform &&
+        (strcmp(platform, PLATFORM_DPDK) == 0 ||
+         strcmp(platform, PLATFORM_NIC) == 0)) {
+        return 20914;
+    }
+    return 0;
+}
+
+uint32_t
+get_ip()
+{
+    return 0x7f000001;
+}
+
+int
+get_protocol()
+{
+    const char *platform = read_string(DEFAULT_SECTION, PLATFORM_KEY);
+    if (platform &&
+        (strcmp(platform, PLATFORM_DPDK) == 0 ||
+         strcmp(platform, PLATFORM_NIC) == 0)) {
+        return 0;
+    }
+    return NETLINK_GENERIC;
+}
+
+int
+get_platform(void)
+{
+    const char *platform = read_string(DEFAULT_SECTION, PLATFORM_KEY);
+
+    if (platform) {
+        if (!strcmp(platform, PLATFORM_DPDK))
+            return DPDK_PLATFORM;
+        else if (!strcmp(platform, PLATFORM_NIC))
+            return NIC_PLATFORM;
+        else
+            return LINUX_PLATFORM;
+    }
+
+    return LINUX_PLATFORM;
+}
+

--- a/utils/mirror.c
+++ b/utils/mirror.c
@@ -35,9 +35,11 @@
 #include "vr_genetlink.h"
 #include "nl_util.h"
 #include "vr_os.h"
+#include "ini_parser.h"
 
 static struct nl_client *cl;
 static bool dump_pending = false;
+static bool response_pending = true;
 static int dump_marker = -1;
 
 static int create_set, delete_set, dump_set;
@@ -50,7 +52,7 @@ void
 vr_mirror_req_process(void *s_req)
 {
    vr_mirror_req *req = (vr_mirror_req *)s_req;
-   unsigned char flags[12];
+   char flags[12];
 
 
    memset(flags, 0, sizeof(flags));
@@ -66,34 +68,41 @@ vr_mirror_req_process(void *s_req)
    if (mirror_op == SANDESH_OP_DUMP)
        dump_marker = req->mirr_index;
 
+   response_pending = false;
    return;
 }
 
 void
 vr_response_process(void *s)
 {
-   vr_response *resp = (vr_response *)s;
-
+    vr_response *resp = (vr_response *)s;
+    response_pending = false;
     if (resp->resp_code < 0) {
         printf("Error: %s\n", strerror(-resp->resp_code));
     } else {
         if (mirror_op == SANDESH_OP_DUMP) {
-            if (resp->resp_code & VR_MESSAGE_DUMP_INCOMPLETE)
+            if (resp->resp_code > 0)
+                response_pending = true;
+
+            if (resp->resp_code & VR_MESSAGE_DUMP_INCOMPLETE) {
                 dump_pending = true;
-            else
-                dump_pending = false; 
+                response_pending = true;
+            } else {
+                dump_pending = false;
+            }
         }
     }
 
     return;
 }
 
-static int 
+static int
 vr_mirror_op(void)
 {
     vr_mirror_req mirror_req;
     int ret, error, attr_len;
     struct nl_response *resp;
+    struct nlmsghdr *nlh;
 
 op_retry:
     mirror_req.h_op = mirror_op;
@@ -126,9 +135,9 @@ op_retry:
     }
 
     attr_len = nl_get_attr_hdr_size();
-     
+
     error = 0;
-    ret = sandesh_encode(&mirror_req, "vr_mirror_req", vr_find_sandesh_info, 
+    ret = sandesh_encode(&mirror_req, "vr_mirror_req", vr_find_sandesh_info,
                              (nl_get_buf_ptr(cl) + attr_len),
                              (nl_get_buf_len(cl) - attr_len), &error);
 
@@ -140,13 +149,21 @@ op_retry:
     nl_build_attr(cl, ret, NL_ATTR_VR_MESSAGE_PROTOCOL);
     nl_update_nlh(cl);
 
+    response_pending = true;
     /* Send the request to kernel */
     ret = nl_sendmsg(cl);
-    while ((ret = nl_recvmsg(cl)) > 0) {
-        resp = nl_parse_reply(cl);
-        if (resp->nl_op == SANDESH_REQUEST) {
-            sandesh_decode(resp->nl_data, resp->nl_len, vr_find_sandesh_info, &ret);
+    while (response_pending) {
+        if ((ret = nl_recvmsg(cl)) > 0) {
+            resp = nl_parse_reply(cl);
+            if (resp->nl_op == SANDESH_REQUEST) {
+                sandesh_decode(resp->nl_data, resp->nl_len,
+                               vr_find_sandesh_info, &ret);
+            }
         }
+
+        nlh = (struct nlmsghdr *)cl->cl_buf;
+        if (!nlh->nlmsg_flags)
+            break;
     }
 
     if (dump_pending)
@@ -357,10 +374,17 @@ int main(int argc, char *argv[])
         exit(1);
     }
 
-    ret = nl_socket(cl, NETLINK_GENERIC);    
+    parse_ini_file();
+    ret = nl_socket(cl, get_domain(), get_type(), get_protocol());
     if (ret <= 0) {
        exit(1);
     }
+
+    ret = nl_connect(cl, get_ip(), get_port());
+    if (ret < 0) {
+        exit(1);
+    }
+
 
     if (vrouter_get_family_id(cl) <= 0) {
         return -1;

--- a/utils/nh.c
+++ b/utils/nh.c
@@ -35,8 +35,9 @@
 #include "vr_genetlink.h"
 #include "vr_os.h"
 #include "nl_util.h"
+#include "ini_parser.h"
 
-static nh_set;
+static int nh_set;
 static struct nl_client *cl;
 static int8_t src_mac[6], dst_mac[6];
 static uint32_t nh_id, if_id, vrf_id ;
@@ -46,6 +47,7 @@ static uint16_t sport, dport;
 static int command;
 static int type;
 static bool dump_pending = false;
+static bool response_pending = true;
 static int dump_marker = -1;
 static int comp_nh[10];
 static int lbl[10];
@@ -100,7 +102,7 @@ nh_flags(uint16_t flags, uint8_t type, char *ptr)
         case NH_FLAG_POLICY_ENABLED:
             strcat(ptr, "Policy, ");
             break;
-        
+
         case NH_FLAG_RELAXED_POLICY:
             strcat(ptr, "Policy(R), ");
             break;
@@ -178,7 +180,7 @@ vr_nexthop_req_process(void *s_req)
         strcpy(fam, "AF_BRIDGE");
     else if (req->nhr_family == AF_UNSPEC)
         strcpy(fam, "AF_UNSPEC");
-    else 
+    else
         strcpy(fam, "N/A");
 
     printf("Id:%03d  Type:%-8s  Fmly:%8s  Flags:%s  Rid:%d  Ref_cnt:%d Vrf:%d\n",
@@ -210,7 +212,7 @@ vr_nexthop_req_process(void *s_req)
         printf("  Dip:%s\n", inet_ntoa(a));
 
         if (req->nhr_flags & NH_FLAG_TUNNEL_UDP) {
-            printf("        Sport:%d Dport:%d\n", ntohs(req->nhr_tun_sport), 
+            printf("        Sport:%d Dport:%d\n", ntohs(req->nhr_tun_sport),
                                                   ntohs(req->nhr_tun_dport));
         }
     }
@@ -229,9 +231,11 @@ vr_nexthop_req_process(void *s_req)
         printf("\n");
     }
 
-    if (command == 3)
+    if (command == 3) {
         dump_marker = req->nhr_id;
+    }
 
+    response_pending = false;
     printf("\n");
 }
 
@@ -239,28 +243,36 @@ void
 vr_response_process(void *s)
 {
    vr_response *resp = (vr_response *)s;
+
+   response_pending = false;
     if (resp->resp_code < 0) {
         printf("Error %s in kernel operation\n", strerror(-resp->resp_code));
     } else {
         if (command == 3) {
-            if (resp->resp_code & VR_MESSAGE_DUMP_INCOMPLETE)
+            if (resp->resp_code > 0)
+                response_pending = true;
+
+            if (resp->resp_code & VR_MESSAGE_DUMP_INCOMPLETE) {
                 dump_pending = true;
-            else
+                response_pending = true;
+            } else {
                 dump_pending = false;
+            }
         }
     }
 
     return;
 }
 
-int 
-vr_nh_op(int opt, int mode, uint32_t nh_id, uint32_t if_id, uint32_t vrf_id, 
+int
+vr_nh_op(int opt, int mode, uint32_t nh_id, uint32_t if_id, uint32_t vrf_id,
         int8_t *dst, int8_t  *src, struct in_addr sip, struct in_addr dip, uint16_t flags)
 {
     vr_nexthop_req nh_req;
     char *buf;
     int ret, error, attr_len;
     struct nl_response *resp;
+    struct nlmsghdr *nlh;
     int i;
 
 op_retry:
@@ -283,7 +295,7 @@ op_retry:
         nh_req.nhr_tun_sport = htons(sport);
         nh_req.nhr_tun_dport = htons(dport);
         nh_req.nhr_nh_list_size = 0;
-        if ((mode == NH_TUNNEL) || 
+        if ((mode == NH_TUNNEL) ||
                 ((mode == NH_ENCAP) && !(flags & NH_FLAG_ENCAP_L2))) {
             nh_req.nhr_encap_size = 14;
             buf = calloc(1, nh_req.nhr_encap_size);
@@ -319,7 +331,7 @@ op_retry:
     nh_req.nhr_id = nh_id;
     nh_req.nhr_rid = 0;
 
-    if ((mode == NH_ENCAP) && (flags & NH_FLAG_ENCAP_L2)) 
+    if ((mode == NH_ENCAP) && (flags & NH_FLAG_ENCAP_L2))
         nh_req.nhr_family = AF_BRIDGE;
     else
         nh_req.nhr_family = AF_INET;
@@ -338,9 +350,9 @@ op_retry:
     }
 
     attr_len = nl_get_attr_hdr_size();
-     
+
     error = 0;
-    ret = sandesh_encode(&nh_req, "vr_nexthop_req", vr_find_sandesh_info, 
+    ret = sandesh_encode(&nh_req, "vr_nexthop_req", vr_find_sandesh_info,
                              (nl_get_buf_ptr(cl) + attr_len),
                              (nl_get_buf_len(cl) - attr_len), &error);
 
@@ -352,13 +364,20 @@ op_retry:
     nl_build_attr(cl, ret, NL_ATTR_VR_MESSAGE_PROTOCOL);
     nl_update_nlh(cl);
 
+    response_pending = true;
     /* Send the request to kernel */
     ret = nl_sendmsg(cl);
-    while ((ret = nl_recvmsg(cl)) > 0) {
-        resp = nl_parse_reply(cl);
-        if (resp->nl_op == SANDESH_REQUEST) {
-            sandesh_decode(resp->nl_data, resp->nl_len, vr_find_sandesh_info, &ret);
+    while (response_pending) {
+        if ((ret = nl_recvmsg(cl)) > 0) {
+            resp = nl_parse_reply(cl);
+            if (resp->nl_op == SANDESH_REQUEST) {
+                sandesh_decode(resp->nl_data, resp->nl_len, vr_find_sandesh_info, &ret);
+            }
         }
+
+        nlh = (struct nlmsghdr *)cl->cl_buf;
+        if (!nlh->nlmsg_flags)
+            break;
     }
 
     if (dump_pending)
@@ -529,7 +548,7 @@ parse_long_opts(int ind, char *opt_arg)
             break;
         case OIF_OPT_IND:
             if_id = strtoul(opt_arg, NULL, 0);
-            if (errno) 
+            if (errno)
                 usage();
             break;
         case SMAC_OPT_IND:
@@ -548,12 +567,12 @@ parse_long_opts(int ind, char *opt_arg)
             break;
         case VRF_OPT_IND:
             vrf_id = strtoul(opt_arg, NULL, 0);
-            if (errno) 
+            if (errno)
                 usage();
             break;
         case TYPE_OPT_IND:
             type = strtoul(opt_arg, NULL, 0);
-            if (errno) 
+            if (errno)
                 usage();
             break;
         case SIP_OPT_IND:
@@ -564,7 +583,7 @@ parse_long_opts(int ind, char *opt_arg)
             break;
         case SPORT_OPT_IND:
             sport = strtoul(opt_arg, NULL, 0);
-            if (errno) 
+            if (errno)
                 usage();
             break;
         case CNI_OPT_IND:
@@ -578,7 +597,7 @@ parse_long_opts(int ind, char *opt_arg)
                 usage();
         case DPORT_OPT_IND:
             dport = strtoul(opt_arg, NULL, 0);
-            if (errno) 
+            if (errno)
                 usage();
     }
 }
@@ -626,7 +645,7 @@ validate_options()
                 if (memcmp(opt, zero_opt, sizeof(opt)))
                     cmd_usage();
             } else if (type == NH_ENCAP) {
-                if (!opt_set(OIF_OPT_IND)) 
+                if (!opt_set(OIF_OPT_IND))
                     cmd_usage();
 
                 if (!opt_set(EL2_OPT_IND)) {
@@ -646,9 +665,10 @@ validate_options()
                 }
 
                 if (opt_set(UDP_OPT_IND)) {
-                    flags |= NH_FLAG_TUNNEL_UDP;
                     if (!opt_set(SPORT_OPT_IND) || !opt_set(DPORT_OPT_IND))
-                        cmd_usage();
+                        flags |= NH_FLAG_TUNNEL_UDP_MPLS;
+                    else
+                        flags |= NH_FLAG_TUNNEL_UDP;
                 } else if (opt_set(VXLAN_OPT_IND)) {
                     flags |= NH_FLAG_TUNNEL_VXLAN;
                     if (!opt_set(SPORT_OPT_IND) || !opt_set(DPORT_OPT_IND))
@@ -721,9 +741,16 @@ int main(int argc, char *argv[])
         exit(1);
     }
 
-    ret = nl_socket(cl, NETLINK_GENERIC);    
+    parse_ini_file();
+
+    ret = nl_socket(cl, get_domain(), get_type(), get_protocol());
     if (ret <= 0) {
-       exit(1);
+        exit(1);
+    }
+
+    ret = nl_connect(cl, get_ip(), get_port());
+    if (ret < 0) {
+        exit(1);
     }
 
     if (vrouter_get_family_id(cl) <= 0) {

--- a/utils/nl_util.c
+++ b/utils/nl_util.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
+#include <stdbool.h>
 #include <errno.h>
 #include <stdlib.h>
 #include <assert.h>
@@ -23,22 +24,23 @@
 
 #include <stdint.h>
 #include <net/if.h>
+#include <netinet/in.h>
+#include "vr_types.h"
 #include "nl_util.h"
 #include "vr_genetlink.h"
 #include "vr_os.h"
 
 #define VROUTER_GENETLINK_FAMILY_NAME "vrouter"
-
-unsigned int nl_client_ids;
+#define GENL_ID_VROUTER         (NLMSG_MIN_TYPE + 0x10)
 
 extern struct nl_response *nl_parse_gen(struct nl_client *);
 
 extern void vr_ops_process (void *a) __attribute__((weak));
-extern void vr_flow_req_process(void *s_req) __attribute__((weak)); 
-extern void vr_route_req_process(void *s_req) __attribute__((weak)); 
-extern void vr_interface_req_process(void *s_req) __attribute__((weak)); 
+extern void vr_flow_req_process(void *s_req) __attribute__((weak));
+extern void vr_route_req_process(void *s_req) __attribute__((weak));
+extern void vr_interface_req_process(void *s_req) __attribute__((weak));
 extern void vr_mpls_req_process(void *s_req) __attribute__((weak));
-extern void vr_mirror_req_process(void *s_req) __attribute__((weak)); 
+extern void vr_mirror_req_process(void *s_req) __attribute__((weak));
 extern void vr_response_process(void *s_req) __attribute__((weak));
 extern void vr_nexthop_req_process(void *s_req) __attribute__((weak));
 extern void vr_vrf_assign_req_process(void *s_req) __attribute__((weak));
@@ -47,7 +49,7 @@ extern void vr_drop_stats_req_process(void *s_req) __attribute__((weak));
 extern void vr_vxlan_req_process(void *s_req) __attribute__((weak));
 
 void
-vrouter_ops_process(void *s_req) 
+vrouter_ops_process(void *s_req)
 {
     return;
 }
@@ -60,19 +62,19 @@ vr_nexthop_req_process(void *s_req)
 
 
 void
-vr_flow_req_process(void *s_req) 
+vr_flow_req_process(void *s_req)
 {
     return;
 }
 
 void
-vr_route_req_process(void *s_req) 
+vr_route_req_process(void *s_req)
 {
     return;
 }
 
 void
-vr_interface_req_process(void *s_req) 
+vr_interface_req_process(void *s_req)
 {
     return;
 }
@@ -84,38 +86,38 @@ vr_mpls_req_process(void *s_req)
 }
 
 void
-vr_mirror_req_process(void *s_req) 
+vr_mirror_req_process(void *s_req)
 {
     return;
 }
 
 void
-vr_response_process(void *s_req) 
+vr_response_process(void *s_req)
 {
     return;
 }
 
 
 void
-vr_vrf_assign_req_process(void *s_req) 
+vr_vrf_assign_req_process(void *s_req)
 {
     return;
 }
 
 void
-vr_vrf_stats_req_process(void *s_req) 
+vr_vrf_stats_req_process(void *s_req)
 {
     return;
 }
 
 void
-vr_drop_stats_req_process(void *s_req) 
+vr_drop_stats_req_process(void *s_req)
 {
     return;
 }
 
 void
-vr_vxlan_req_process(void *s_req) 
+vr_vxlan_req_process(void *s_req)
 {
     return;
 }
@@ -143,7 +145,7 @@ nl_parse_gen_ctrl(struct nl_client *cl)
 
         switch (nla->nla_type) {
         case CTRL_ATTR_FAMILY_NAME:
-            strncpy(msg->family_name, NLA_DATA(nla), GENL_FAMILY_NAME_LEN - 1);
+            strncpy(msg->family_name, NLA_DATA(nla), sizeof(msg->family_name) - 1);
             break;
 
         case CTRL_ATTR_FAMILY_ID:
@@ -165,7 +167,7 @@ nl_parse_gen_ctrl(struct nl_client *cl)
 
 struct nl_response *
 nl_parse_gen(struct nl_client *cl)
-{   
+{
     char *buf = cl->cl_buf + cl->cl_buf_offset;
     struct genlmsghdr *ghdr;
     struct nl_response *resp = &cl->resp;
@@ -190,7 +192,7 @@ nl_parse_gen(struct nl_client *cl)
 }
 
 static int
-nl_build_sandesh_attr_without_attr_len(struct nl_client *cl) 
+nl_build_sandesh_attr_without_attr_len(struct nl_client *cl)
 {
     struct nlattr *nla = (struct nlattr *)
         ((char *)cl->cl_buf + cl->cl_buf_offset);
@@ -198,9 +200,9 @@ nl_build_sandesh_attr_without_attr_len(struct nl_client *cl)
     if (cl->cl_buf_offset + NLA_HDRLEN > cl->cl_buf_len)
         return -ENOMEM;
 
-	nla->nla_len = NLA_HDRLEN;
-	nla->nla_type = NL_ATTR_VR_MESSAGE_PROTOCOL;
-	cl->cl_buf_offset += NLA_HDRLEN;
+    nla->nla_len = NLA_HDRLEN;
+    nla->nla_type = NL_ATTR_VR_MESSAGE_PROTOCOL;
+    cl->cl_buf_offset += NLA_HDRLEN;
 
     return 0;
 }
@@ -230,7 +232,7 @@ nl_build_header(struct nl_client *cl, unsigned char **buf, uint32_t *buf_len)
 
     *buf = (unsigned char *)(cl->cl_buf) + cl->cl_buf_offset;
     *buf_len = cl->cl_buf_len - cl->cl_buf_offset;
-    
+
     return 0;
 }
 
@@ -244,7 +246,6 @@ nl_update_header(struct nl_client *cl, int data_len)
     assert(nla->nla_type == NL_ATTR_VR_MESSAGE_PROTOCOL);
     nla->nla_len +=  data_len;
 
-    /* Update the netlink header len */
     cl->cl_buf_offset += data_len;
     nl_update_nlh(cl);
 }
@@ -302,7 +303,7 @@ nl_build_get_family_id(struct nl_client *cl, char *family)
     nl_update_nlh(cl);
 
     return 0;
-}       
+}
 
 int
 nl_build_genlh(struct nl_client *cl, uint8_t cmd, uint8_t version)
@@ -409,71 +410,100 @@ nl_free(struct nl_client *cl)
     if (cl->cl_resp_buf)
         free(cl->cl_resp_buf);
 
+    if (cl->cl_sa)
+        free(cl->cl_sa);
+
     cl->cl_buf = NULL;
     cl->cl_resp_buf = NULL;
     cl->cl_buf_offset = 0;
     cl->cl_buf_len = 0;
     cl->cl_resp_buf_len = 0;
+    cl->cl_sa = NULL;
+    cl->cl_sa_len = 0;
+    cl->cl_recvmsg = NULL;
 
     return;
 }
 
 int
-nl_socket(struct nl_client *cl, unsigned int protocol)
+nl_socket(struct nl_client *cl,int domain, int type, int protocol)
 {
-#if defined(__linux__)
-    struct sockaddr_nl sa;
-#endif
-
     if (cl->cl_sock >= 0)
         return -EEXIST;
 
-#if defined(__linux__)
-    cl->cl_sock = socket(AF_NETLINK, SOCK_DGRAM, protocol);
-#elif defined(__FreeBSD__)
+#if defined(__FreeBSD__)
     /*
      * Fake Contrail socket has only one protocol for handling
      * sandesh protocol, so zero must be passed as a parameter
      */
-    cl->cl_sock = socket(AF_VENDOR00, SOCK_DGRAM, 0);
+    domain = AF_VENDOR00;
+    type = SOCK_DGRAM;
+    protocol = 0;
 #endif
+    cl->cl_sock = socket(domain, type, protocol);
     if (cl->cl_sock < 0)
         return cl->cl_sock;
 
-#if defined(__linux__)
-    /* In simple configuration we test on BSD, binding is not
-     * required. It will be implemented later.
-     */
-    memset(&sa, 0, sizeof(sa));
-    sa.nl_family = AF_NETLINK;
-    sa.nl_pid = cl->cl_id;
-    bind(cl->cl_sock, (struct sockaddr *)&sa, sizeof(sa));
-#endif
-
     cl->cl_sock_protocol = protocol;
+    cl->cl_socket_domain = domain;
+    cl->cl_socket_type = type;
+
+    if (type == SOCK_STREAM) {
+        cl->cl_recvmsg = nl_client_stream_recvmsg;
+    } else {
+        cl->cl_recvmsg = nl_client_datagram_recvmsg;
+    }
 
     return cl->cl_sock;
 }
 
+int
+nl_connect(struct nl_client *cl, uint32_t ip, uint16_t port)
+{
+    if (cl->cl_socket_domain == AF_NETLINK) {
+        struct sockaddr_nl *sa = malloc(sizeof(struct sockaddr_nl));
+
+        if (!sa)
+            return -1;
+
+        memset(sa, 0, sizeof(*sa));
+        sa->nl_family = cl->cl_socket_domain;
+        sa->nl_pid = cl->cl_id;
+        cl->cl_sa = (struct sockaddr *)sa;
+        cl->cl_sa_len = sizeof(*sa);
+
+        return bind(cl->cl_sock, cl->cl_sa, cl->cl_sa_len);
+    }
+
+    if (cl->cl_socket_domain == AF_INET) {
+        struct in_addr address;
+        struct sockaddr_in *sa = malloc(sizeof(struct sockaddr_in));
+        if (!sa)
+            return -1;
+
+        memset(sa, 0, sizeof(*sa));
+        address.s_addr = htonl(ip);
+        sa->sin_family = cl->cl_socket_domain;
+        sa->sin_addr = address;
+        sa->sin_port = htons(port);
+        cl->cl_sa = (struct sockaddr *)sa;
+        cl->cl_sa_len = sizeof(*sa);
+
+        return connect(cl->cl_sock, cl->cl_sa, cl->cl_sa_len);
+    }
+    return 0;
+}
 
 int
-nl_recvmsg(struct nl_client *cl)
+nl_client_datagram_recvmsg(struct nl_client *cl)
 {
     int ret;
-#if defined (__linux__)
-    struct sockaddr_nl sa;
-#endif
     struct msghdr msg;
     struct iovec iov;
 
     memset(&msg, 0, sizeof(msg));
-#if defined(__linux__)
-    memset(&sa, 0, sizeof(sa));
-    sa.nl_family = AF_NETLINK;
-
-    msg.msg_name = &sa;
-    msg.msg_namelen = sizeof(sa);
-#endif
+    msg.msg_name = cl->cl_sa;
+    msg.msg_namelen = cl->cl_sa_len;
 
     iov.iov_base = (void *)(cl->cl_buf);
     iov.iov_len = cl->cl_buf_len;
@@ -495,21 +525,64 @@ nl_recvmsg(struct nl_client *cl)
 }
 
 int
+nl_client_stream_recvmsg(struct nl_client *cl) {
+    int ret;
+    struct msghdr msg;
+    struct iovec iov;
+
+    memset(&msg, 0, sizeof(msg));
+
+    msg.msg_name = cl->cl_sa;
+    msg.msg_namelen = sizeof(cl->cl_sa_len);
+
+    iov.iov_base = (void *)(cl->cl_buf);
+    iov.iov_len = sizeof(struct nlmsghdr);
+    msg.msg_iov = &iov;
+    msg.msg_iovlen = 1;
+
+    cl->cl_buf_offset = 0;
+
+    //Read netlink header and get the lenght of sandesh message
+    ret = recvmsg(cl->cl_sock, &msg, 0);
+    if (ret < 0) {
+        return ret;
+    }
+    struct nlmsghdr *nlh = (struct nlmsghdr *)(cl->cl_buf + cl->cl_buf_offset);
+    uint32_t pending_length = nlh->nlmsg_len - sizeof(struct nlmsghdr);
+
+    //Read sandesh message
+    iov.iov_base = (void *)(cl->cl_buf + sizeof(struct nlmsghdr));
+    iov.iov_len = pending_length;
+    msg.msg_iov = &iov;
+    msg.msg_iovlen = 1;
+    ret = recvmsg(cl->cl_sock, &msg, 0);
+    if (ret < 0) {
+        return ret;
+    }
+
+    cl->cl_recv_len = nlh->nlmsg_len;
+    if (cl->cl_recv_len > cl->cl_buf_len)
+        return -EOPNOTSUPP;
+
+    return ret;
+}
+
+int
+nl_recvmsg(struct nl_client *cl)
+{
+    return cl->cl_recvmsg(cl);
+}
+
+int
 nl_sendmsg(struct nl_client *cl)
 {
-#if defined (__linux__)
-    struct sockaddr_nl sa;
-#endif
     struct msghdr msg;
     struct iovec iov;
 
     memset(&msg, 0, sizeof(msg));
 #if defined (__linux__)
-    memset(&sa, 0, sizeof(sa));
-    sa.nl_family = AF_NETLINK;
-
-    msg.msg_name = &sa;
-    msg.msg_namelen = sizeof(sa);
+    msg.msg_name = cl->cl_sa;
+    msg.msg_namelen = cl->cl_sa_len;
 #endif
 
     iov.iov_base = (void *)(cl->cl_buf);
@@ -573,9 +646,7 @@ nl_register_client(void)
         goto exit_register;
     cl->cl_resp_buf_len = NL_RESP_DEFAULT_SIZE;
 
-    /* this really is OK... */
-    cl->cl_id = __sync_fetch_and_add(&nl_client_ids, 1);
-
+    cl->cl_id = 0;
     cl->cl_sock = -1;
 
     return cl;
@@ -644,7 +715,7 @@ nl_parse_reply(struct nl_client *cl)
         resp = nl_parse_gen(cl);
     } else {
         return nl_set_resp_err(cl, NL_MSG_TYPE_ERROR);
-    }   
+    }
     return resp;
 }
 
@@ -656,14 +727,26 @@ vrouter_get_family_id(struct nl_client *cl)
     struct genl_ctrl_message *msg;
 
 #if defined(__linux__)
+    if (cl->cl_socket_domain != AF_NETLINK) {
+        nl_set_genl_family_id(cl, GENL_ID_VROUTER);
+        return GENL_ID_VROUTER;
+    }
+
     if ((ret = nl_build_get_family_id(cl, VROUTER_GENETLINK_FAMILY_NAME)))
         return ret;
 
     if (nl_sendmsg(cl) <= 0)
         return -errno;
 
-    if (nl_recvmsg(cl) <= 0)
+    while (1) {
+        ret = nl_recvmsg(cl);
+        if (ret == EAGAIN)
+            continue;
+        else if (ret > 0)
+            break;
+
         return -errno;
+    }
 
     resp = nl_parse_reply(cl);
     if (!resp || resp->nl_type != NL_MSG_TYPE_GEN_CTRL ||

--- a/utils/nl_util.c
+++ b/utils/nl_util.c
@@ -426,7 +426,7 @@ nl_free(struct nl_client *cl)
 }
 
 int
-nl_socket(struct nl_client *cl,int domain, int type, int protocol)
+nl_socket(struct nl_client *cl, int domain, int type, int protocol)
 {
     if (cl->cl_sock >= 0)
         return -EEXIST;

--- a/utils/rt.c
+++ b/utils/rt.c
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <getopt.h>
+#include <inttypes.h>
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -38,11 +39,13 @@
 #include "vr_route.h"
 #include "vr_bridge.h"
 #include "vr_os.h"
+#include "vr_message.h"
+#include "ini_parser.h"
 
 static struct nl_client *cl;
 static int resp_code;
 static vr_route_req rt_req;
-static uint8_t rt_prefix[16], rt_src[16], rt_marker[16];
+static uint8_t rt_prefix[16], rt_marker[16];
 static bool cmd_proxy_set = false;
 static bool cmd_trap_set = false;
 static bool cmd_flood_set = false;
@@ -62,6 +65,7 @@ static uint32_t cmd_plen = 0;
 static int32_t cmd_label;
 static uint32_t cmd_replace_plen = 100;
 static char cmd_dst_mac[6];
+static bool response_pending = true;
 static void Usage(void);
 static void usage_internal(void);
 
@@ -132,14 +136,13 @@ void
 vr_route_req_process(void *s_req)
 {
     int ret = 0, i;
-    int8_t addr[17];
+    char addr[17];
     char flags[32];
     vr_route_req *rt = (vr_route_req *)s_req;
 
     if (!rt_req.rtr_prefix) {
-        rt_req.rtr_prefix = rt_prefix;
-        rt_req.rtr_marker = rt_marker;
-            
+        rt_req.rtr_prefix = (int8_t *)rt_prefix;
+        rt_req.rtr_marker = (int8_t *)rt_marker;
     }
     rt_req.rtr_prefix_size = rt_req.rtr_marker_size = 0;
 
@@ -152,7 +155,7 @@ vr_route_req_process(void *s_req)
         memset(rt_req.rtr_prefix, 0, 16);
         memset(rt_req.rtr_marker, 0, 16);
     }
-        
+
     rt_req.rtr_prefix_len = rt->rtr_prefix_len;
     if (rt->rtr_mac) {
         if (!rt_req.rtr_mac) {
@@ -238,6 +241,7 @@ vr_route_req_process(void *s_req)
         printf(" %10d\n", rt->rtr_nh_id);
     }
 
+    response_pending = false;
     return;
 }
 
@@ -248,17 +252,26 @@ vr_response_process(void *s)
 
     rt_resp = (vr_response *)s;
     resp_code = rt_resp->resp_code;
-
-    if (rt_resp->resp_code < 0)
+    response_pending = false;
+    if (rt_resp->resp_code < 0) {
         printf("Error %s in kernel operation\n", strerror(rt_resp->resp_code));
+    } else {
+        if (cmd_op == SANDESH_OP_DUMP) {
+            if (rt_resp->resp_code > 0)
+                response_pending = true;
 
+            if (rt_resp->resp_code & VR_MESSAGE_DUMP_INCOMPLETE) {
+                response_pending = true;
+            }
+        }
+    }
     return;
 }
 
 
 static vr_route_req *
-vr_build_route_request(unsigned int op, int family, int8_t *prefix, 
-        unsigned int p_len, unsigned int nh_id, unsigned int vrf, int label, 
+vr_build_route_request(unsigned int op, int family, uint8_t *prefix,
+        unsigned int p_len, unsigned int nh_id, unsigned int vrf, int label,
         char *eth, uint32_t replace_plen)
 {
     int i;
@@ -269,8 +282,8 @@ vr_build_route_request(unsigned int op, int family, int8_t *prefix,
     rt_req.h_op = op;
 
     if (!rt_req.rtr_prefix) {
-        rt_req.rtr_prefix = rt_prefix;
-        rt_req.rtr_marker = rt_marker;
+        rt_req.rtr_prefix = (int8_t *)rt_prefix;
+        rt_req.rtr_marker = (int8_t *)rt_marker;
     }
     rt_req.rtr_prefix_size = rt_req.rtr_marker_size = 0;
 
@@ -301,9 +314,9 @@ vr_build_route_request(unsigned int op, int family, int8_t *prefix,
             rt_req.rtr_prefix_size = RT_IP_ADDR_SIZE(family);
 
             inet_ntop(family, rt_req.rtr_prefix, buf, sizeof(buf));
-            printf ("Adding prefix %s \n Prefix: ", buf);
-            for (i = 0; i < RT_IP_ADDR_SIZE(family); i++) {
-                 printf("%x:", prefix[i]);
+            printf ("Adding prefix %s \n Prefix: %" PRIx8, buf, prefix[0]);
+            for (i=1; i< RT_IP_ADDR_SIZE(family); i++) {
+                 printf(":%" PRIx8, prefix[i]);
             }
             printf ("\n");
         } else {
@@ -337,7 +350,7 @@ vr_build_route_request(unsigned int op, int family, int8_t *prefix,
         } else {
             rt_req.rtr_mac = calloc(1,6);
             rt_req.rtr_mac_size = 6;
-            memcpy(rt_req.rtr_mac, eth, 6); 
+            memcpy(rt_req.rtr_mac, eth, 6);
             if (label != -1) {
                 rt_req.rtr_label = label;
                 rt_req.rtr_label_flags |= VR_BE_LABEL_VALID_FLAG;
@@ -365,7 +378,7 @@ vr_build_netlink_request(vr_route_req *req)
         return ret;
 
     attr_len = nl_get_attr_hdr_size();
-    ret = sandesh_encode(req, "vr_route_req", vr_find_sandesh_info, 
+    ret = sandesh_encode(req, "vr_route_req", vr_find_sandesh_info,
                              (nl_get_buf_ptr(cl) + attr_len),
                              (nl_get_buf_len(cl) - attr_len), &error);
 
@@ -389,12 +402,15 @@ vr_send_one_message(void)
     if (ret <= 0)
         return 0;
 
-    while ((ret = nl_recvmsg(cl)) > 0) {
-        resp = nl_parse_reply(cl);
-        if (resp->nl_op == SANDESH_REQUEST)
-            sandesh_decode(resp->nl_data, resp->nl_len, vr_find_sandesh_info, &ret);
+    response_pending = true;
+    while (response_pending) {
+        if ((ret = nl_recvmsg(cl)) > 0) {
+            resp = nl_parse_reply(cl);
+            if (resp->nl_op == SANDESH_REQUEST)
+                sandesh_decode(resp->nl_data, resp->nl_len,
+                               vr_find_sandesh_info, &ret);
+        }
     }
-
     return resp_code;
 }
 
@@ -402,8 +418,9 @@ static void
 vr_route_dump(void)
 {
     while (vr_send_one_message() != 0) {
-        vr_build_route_request(SANDESH_OP_DUMP, rt_req.rtr_family, rt_req.rtr_marker,
-                rt_req.rtr_marker_plen, 0, rt_req.rtr_vrf_id, 0, 
+        vr_build_route_request(SANDESH_OP_DUMP, rt_req.rtr_family,
+                (uint8_t *)rt_req.rtr_marker,
+                rt_req.rtr_marker_plen, 0, rt_req.rtr_vrf_id, 0,
                 (char *)rt_req.rtr_mac, 0);
         vr_build_netlink_request(&rt_req);
     }
@@ -422,7 +439,7 @@ vr_do_route_op(int op)
     return;
 }
 
-static int 
+static int
 vr_route_op(void)
 {
     vr_route_req *req;
@@ -638,7 +655,7 @@ main(int argc, char *argv[])
 
             case 'v':
                 cmd_vrf_id = atoi(optarg);
-                break;      
+                break;
 
             case 'n':
                 cmd_nh_id = atoi(optarg);
@@ -723,9 +740,15 @@ main(int argc, char *argv[])
         exit(1);
     }
 
-    ret = nl_socket(cl, NETLINK_GENERIC);    
+    parse_ini_file();
+
+    ret = nl_socket(cl, get_domain(), get_type(), get_protocol());
     if (ret <= 0) {
-        printf("nl_socket failed\n");
+        exit(1);
+    }
+
+    ret = nl_connect(cl, get_ip(), get_port());
+    if (ret < 0) {
         exit(1);
     }
 

--- a/utils/udp_util.c
+++ b/utils/udp_util.c
@@ -112,8 +112,8 @@ udp_recvmsg(struct udp_client *cl)
     struct iovec iov;
 
     memset(&msg, 0, sizeof(msg));
-
     memset(&sa, 0, sizeof(sa));
+
     sa.sin_family = AF_INET;
     msg.msg_name = &sa;
     msg.msg_namelen = sizeof(sa);

--- a/utils/vif.c
+++ b/utils/vif.c
@@ -975,8 +975,13 @@ main(int argc, char *argv[])
     validate_options();
 
     cl = nl_register_client();
-    if (!cl)
+    if (!cl) {
+        printf("Error registering NetLink client: %s (%d)\n",
+                strerror(errno), errno);
         exit(-ENOMEM);
+    }
+
+    parse_ini_file();
 
 #if defined(__linux__)
     if (create_set)
@@ -985,21 +990,26 @@ main(int argc, char *argv[])
         sock_proto = get_protocol();
 #endif
 
-    parse_ini_file();
-
     ret = nl_socket(cl, get_domain(), get_type(), sock_proto);
     if (ret <= 0) {
+        printf("Error creating NetLink socket: %s (%d)\n",
+                strerror(errno), errno);
         exit(1);
     }
 
     ret = nl_connect(cl, get_ip(), get_port());
     if (ret < 0) {
+        printf("Error connecting to NetLink socket: %s (%d)\n",
+                strerror(errno), errno);
         exit(1);
     }
 
     if (sock_proto == NETLINK_GENERIC)
-        if (vrouter_get_family_id(cl) <= 0)
+        if (vrouter_get_family_id(cl) <= 0) {
+            printf("Error getting NetLink family: %s (%d)\n",
+                    strerror(errno), errno);
             return -1;
+        }
 
     if (add_set) {
         /*

--- a/utils/vifdump
+++ b/utils/vifdump
@@ -1,0 +1,93 @@
+#!/bin/sh
+##
+## vRouter/DPDK vif tcpdump
+##
+
+## Constants
+MON_IF_NAME="mon"
+VR_MAX_INTERFACES=$((256 + 4096))
+MON_TYPE="monitoring"
+
+## Functions
+usage () {
+    echo "vRouter/DPDK vif tcmpdump script"
+    echo "Usage:"
+    echo "      ${0##*/} [-i] <vif> [tcpdump arguments]"
+    echo "              - to run tcpdump on a specified vif"
+    echo "      ${0##*/} stop <monitoring_if>"
+    echo "              - to force stop and clean up the monitoring interface"
+    echo "Example:"
+    echo "      ${0##*/} -i vif0/1 -nvv"
+    exit 1
+}
+
+error () {
+    echo "${0##*/} error: $1"
+    exit 1
+}
+
+monitoring_stop () {
+    if [ $# -lt 1 ]; then
+        usage
+    fi
+    MONITORING_VIF_ID=${1##vif0/}
+    MONITORING_VIF_ID=${MONITORING_VIF_ID##mon}
+    echo "Deleting vif ${MONITORING_VIF_ID}..."
+    sudo vif --delete ${MONITORING_VIF_ID}
+    exit 0
+}
+
+## parse the arguments
+if [ $# -lt 1 ]; then
+    usage
+fi
+
+ARG=${1}; shift
+case ${ARG} in
+    "-i" )
+        ARG=${1}
+        shift
+        ;;
+    "stop" )
+        monitoring_stop ${1};;
+esac
+MONITORED_VIF_ID=${ARG##vif0/}
+
+## check if the monitoring interface is free
+MON_IF_ID=${MONITORED_VIF_ID}
+if ifconfig ${MON_IF_NAME}${MON_IF_ID} >/dev/null 2>&1; then
+    error "monitoring interface ${MON_IF_NAME}${MON_IF_ID} is already in use.\nUse ${0##*/} stop to force stop the monitoring."
+fi
+
+## find free monitoring vif index
+MON_VIF_ID=$((${VR_MAX_INTERFACES} - ${MON_IF_ID} - 1))
+while true; do
+    if ! sudo vif --list | grep "^vif0/${MON_VIF_ID}\b" >/dev/null 2>&1; then
+        break
+    fi
+    MON_VIF_ID=$((${MON_VIF_ID} - 1))
+done
+
+sudo vif --add ${MON_IF_NAME}${MON_IF_ID} --type ${MON_TYPE} \
+    --vif ${MONITORED_VIF_ID} --id ${MON_VIF_ID}
+
+## wait for monitoring interface to appear
+WAIT=10
+while ! ifconfig ${MON_IF_NAME}${MON_IF_ID} >/dev/null 2>&1; do
+    WAIT=$((${WAIT} - 1))
+    if [ "${WAIT}" = "0" ]; then
+        error "no interface ${MON_IF_NAME}${MON_IF_ID}"
+    fi
+done
+
+## disable IPv6 on the monitoring interface
+sudo sh -c "echo 1 > /proc/sys/net/ipv6/conf/${MON_IF_NAME}${MON_IF_ID}/disable_ipv6"
+
+sudo ifconfig ${MON_IF_NAME}${MON_IF_ID} up
+
+## set signal handler
+trap "echo ${0##*/}: deleting vif ${MON_VIF_ID}... && sudo vif --delete ${MON_VIF_ID}" \
+    HUP INT QUIT ABRT PIPE TERM
+
+## run tcpdump with the rest of arguments
+sudo tcpdump -i ${MON_IF_NAME}${MON_IF_ID} $*

--- a/utils/vifdump
+++ b/utils/vifdump
@@ -56,20 +56,27 @@ MONITORED_VIF_ID=${ARG##vif0/}
 ## check if the monitoring interface is free
 MON_IF_ID=${MONITORED_VIF_ID}
 if ifconfig ${MON_IF_NAME}${MON_IF_ID} >/dev/null 2>&1; then
-    error "monitoring interface ${MON_IF_NAME}${MON_IF_ID} is already in use.\nUse ${0##*/} stop to force stop the monitoring."
+    echo "monitoring interface ${MON_IF_NAME}${MON_IF_ID} is already in use"
+    MON_VIF_ID=`sudo vif --list | grep -w ${MON_IF_NAME}${MON_IF_ID} \
+        | cut -d ' ' -f 1 | cut -d '/' -f 2`
+    if [ -n "${MON_VIF_ID}" ]; then
+        error "Use '${0##*/} stop ${MON_VIF_ID}' command to force stop the monitoring."
+    else
+        error "Use 'vif --list' and '${0##*/} stop <id>' commands to force stop the monitoring."
+    fi
 fi
 
 ## find free monitoring vif index
 MON_VIF_ID=$((${VR_MAX_INTERFACES} - ${MON_IF_ID} - 1))
 while true; do
-    if ! sudo vif --list | grep "^vif0/${MON_VIF_ID}\b" >/dev/null 2>&1; then
+    if ! sudo vif --list 2>/dev/null | grep "^vif0/${MON_VIF_ID}\b" >/dev/null 2>&1; then
         break
     fi
     MON_VIF_ID=$((${MON_VIF_ID} - 1))
 done
 
 sudo vif --add ${MON_IF_NAME}${MON_IF_ID} --type ${MON_TYPE} \
-    --vif ${MONITORED_VIF_ID} --id ${MON_VIF_ID}
+    --vif ${MONITORED_VIF_ID} --id ${MON_VIF_ID} >/dev/null
 
 ## wait for monitoring interface to appear
 WAIT=10
@@ -86,8 +93,14 @@ sudo sh -c "echo 1 > /proc/sys/net/ipv6/conf/${MON_IF_NAME}${MON_IF_ID}/disable_
 sudo ifconfig ${MON_IF_NAME}${MON_IF_ID} up
 
 ## set signal handler
-trap "echo ${0##*/}: deleting vif ${MON_VIF_ID}... && sudo vif --delete ${MON_VIF_ID}" \
+trap "echo ${0##*/}: deleting vif ${MON_VIF_ID}... && \
+    sudo vif --delete ${MON_VIF_ID} && exit 0" \
     HUP INT QUIT ABRT PIPE TERM
 
 ## run tcpdump with the rest of arguments
 sudo tcpdump -i ${MON_IF_NAME}${MON_IF_ID} $*
+
+trap "exit 1" \
+    HUP INT QUIT ABRT PIPE TERM
+echo ${0##*/}: deleting vif ${MON_VIF_ID}...
+sudo vif --delete ${MON_VIF_ID}

--- a/utils/vrfstats.c
+++ b/utils/vrfstats.c
@@ -38,6 +38,7 @@
 #include "nl_util.h"
 #include "vr_mpls.h"
 #include "vr_defs.h"
+#include "ini_parser.h"
 
 static struct nl_client *cl;
 static int resp_code;
@@ -47,6 +48,7 @@ static int vrf = -1;
 static int get_set, dump_set;
 static int help_set;
 static bool dump_pending = false;
+static bool response_pending = true;
 
 void
 vr_vrf_stats_req_process(void *s_req)
@@ -64,7 +66,7 @@ vr_vrf_stats_req_process(void *s_req)
             ", Evpn Composites %" PRIu64 "\n", stats->vsr_ecmp_composites,
             stats->vsr_l2_mcast_composites, stats->vsr_fabric_composites,
             stats->vsr_encap_composites, stats->vsr_evpn_composites);
-    printf("Udp Tunnels %" PRIu64 ", Udp Mpls Tunnels %" PRIu64 
+    printf("Udp Tunnels %" PRIu64 ", Udp Mpls Tunnels %" PRIu64
             ", Gre Mpls Tunnels %" PRIu64 ", Vxlan Tunnels %" PRIu64 "\n",
             stats->vsr_udp_tunnels, stats->vsr_udp_mpls_tunnels,
             stats->vsr_gre_mpls_tunnels, stats->vsr_vxlan_tunnels);
@@ -80,6 +82,8 @@ vr_vrf_stats_req_process(void *s_req)
             stats->vsr_arp_tor_proxy, stats->vsr_arp_physical_flood);
 
     printf("\n");
+
+    response_pending = false;
     return;
 }
 
@@ -91,15 +95,21 @@ vr_response_process(void *s)
     stats_resp = (vr_response *)s;
     resp_code = stats_resp->resp_code;
 
+    response_pending = false;
     if (stats_resp->resp_code < 0) {
         printf("Error %s in kernel operation\n", strerror(stats_resp->resp_code));
         exit(-1);
     } else {
         if (stats_op == SANDESH_OP_DUMP) {
-            if (resp_code & VR_MESSAGE_DUMP_INCOMPLETE)
+            if (stats_resp->resp_code > 0)
+                response_pending = true;
+
+            if (resp_code & VR_MESSAGE_DUMP_INCOMPLETE) {
                 dump_pending = true;
-            else 
+                response_pending = true;
+            } else {
                 dump_pending = false;
+            }
         }
     }
 
@@ -145,7 +155,7 @@ vr_build_netlink_request(vr_vrf_stats_req *req)
         return ret;
 
     attr_len = nl_get_attr_hdr_size();
-    ret = sandesh_encode(req, "vr_vrf_stats_req", vr_find_sandesh_info, 
+    ret = sandesh_encode(req, "vr_vrf_stats_req", vr_find_sandesh_info,
                              (nl_get_buf_ptr(cl) + attr_len),
                              (nl_get_buf_len(cl) - attr_len), &error);
 
@@ -165,16 +175,19 @@ vr_send_one_message(void)
     int ret;
     struct nl_response *resp;
 
+    response_pending = true;
     ret = nl_sendmsg(cl);
     if (ret <= 0)
         return 0;
 
-    while ((ret = nl_recvmsg(cl)) > 0) {
-        resp = nl_parse_reply(cl);
-        if (resp->nl_op == SANDESH_REQUEST)
-            sandesh_decode(resp->nl_data, resp->nl_len, vr_find_sandesh_info, &ret);
+    while (response_pending) {
+        if ((ret = nl_recvmsg(cl)) > 0) {
+            resp = nl_parse_reply(cl);
+            if (resp->nl_op == SANDESH_REQUEST)
+                sandesh_decode(resp->nl_data, resp->nl_len,
+                               vr_find_sandesh_info, &ret);
+        }
     }
-
     return resp_code;
 }
 
@@ -205,7 +218,7 @@ vr_do_stats_op(void)
     return;
 }
 
-static int 
+static int
 vr_stats_op(void)
 {
     int ret;
@@ -319,9 +332,16 @@ main(int argc, char *argv[])
         exit(1);
     }
 
-    ret = nl_socket(cl, NETLINK_GENERIC);    
+    parse_ini_file();
+
+    ret = nl_socket(cl, get_domain(), get_type(), get_protocol());
     if (ret <= 0) {
-       exit(1);
+        exit(1);
+    }
+
+    ret = nl_connect(cl, get_ip(), get_port());
+    if (ret < 0) {
+        exit(1);
     }
 
     if (vrouter_get_family_id(cl) <= 0) {

--- a/utils/vxlan.c
+++ b/utils/vxlan.c
@@ -36,9 +36,11 @@
 #include "vr_vxlan.h"
 #include "vr_genetlink.h"
 #include "nl_util.h"
+#include "ini_parser.h"
 
 static struct nl_client *cl;
 static bool dump_pending = false;
+static bool response_pending = true;
 static int op;
 unsigned int dump_marker= 0;
 
@@ -60,31 +62,41 @@ vr_vxlan_req_process(void *s_req)
 
    dump_marker = req->vxlanr_vnid;
 
+   response_pending = false;
+
    return;
 }
 
 void
 vr_response_process(void *s)
 {
-   vr_response *resp = (vr_response *)s;
+    vr_response *resp = (vr_response *)s;
+    response_pending = false;
+
     if (resp->resp_code < 0) {
         printf("Error: %s\n", strerror(-resp->resp_code));
     } else {
         if (op == 4) {
-            if (resp->resp_code & VR_MESSAGE_DUMP_INCOMPLETE)
+            if (resp->resp_code > 0)
+                response_pending = true;
+
+            if (resp->resp_code & VR_MESSAGE_DUMP_INCOMPLETE) {
                 dump_pending = true;
-            else
+                response_pending = true;
+            } else {
                 dump_pending = false;
+            }
         }
     }
 }
 
-static int 
+static int
 vr_vxlan_op(void)
 {
     vr_vxlan_req vxlan_req;
     int ret, error, attr_len;
     struct nl_response *resp;
+    struct nlmsghdr *nlh;
 
 op_retry:
     vxlan_req.h_op = vxlan_op;
@@ -117,9 +129,9 @@ op_retry:
     }
 
     attr_len = nl_get_attr_hdr_size();
-     
+
     error = 0;
-    ret = sandesh_encode(&vxlan_req, "vr_vxlan_req", vr_find_sandesh_info, 
+    ret = sandesh_encode(&vxlan_req, "vr_vxlan_req", vr_find_sandesh_info,
                              (nl_get_buf_ptr(cl) + attr_len),
                              (nl_get_buf_len(cl) - attr_len), &error);
 
@@ -131,13 +143,21 @@ op_retry:
     nl_build_attr(cl, ret, NL_ATTR_VR_MESSAGE_PROTOCOL);
     nl_update_nlh(cl);
 
+    response_pending = true;
     /* Send the request to kernel */
     ret = nl_sendmsg(cl);
-    while ((ret = nl_recvmsg(cl)) > 0) {
-        resp = nl_parse_reply(cl);
-        if (resp->nl_op == SANDESH_REQUEST) {
-            sandesh_decode(resp->nl_data, resp->nl_len, vr_find_sandesh_info, &ret);
+    while (response_pending) {
+        if ((ret = nl_recvmsg(cl)) > 0) {
+            resp = nl_parse_reply(cl);
+            if (resp->nl_op == SANDESH_REQUEST) {
+                sandesh_decode(resp->nl_data, resp->nl_len,
+                               vr_find_sandesh_info, &ret);
+            }
         }
+
+        nlh = (struct nlmsghdr *)cl->cl_buf;
+        if (!nlh->nlmsg_flags)
+            break;
     }
 
     if (dump_pending)
@@ -340,9 +360,16 @@ int main(int argc, char *argv[])
         exit(1);
     }
 
-    ret = nl_socket(cl, NETLINK_GENERIC);    
+    parse_ini_file();
+
+    ret = nl_socket(cl, get_domain(), get_type(), get_protocol());
     if (ret <= 0) {
-       exit(1);
+        exit(1);
+    }
+
+    ret = nl_connect(cl, get_ip(), get_port());
+    if (ret < 0) {
+        exit(1);
     }
 
     if (vrouter_get_family_id(cl) <= 0) {

--- a/uvrouter/uvrouter.c
+++ b/uvrouter/uvrouter.c
@@ -32,7 +32,7 @@ get_random_bytes(void *buf, int nbytes)
 
 
 uint32_t
-jhash(void *key, uint32_t length, uint32_t interval)
+jhash(void *key, uint32_t length, uint32_t initval)
 {
     uint32_t ret;
     int i;


### PR DESCRIPTION
This setting can be overridden by running vRouter via taskset.
